### PR TITLE
기자재 페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/girigiri/kwrental/equipment/EquipmentRepository.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/EquipmentRepository.java
@@ -1,6 +1,8 @@
 package com.girigiri.kwrental.equipment;
 
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.repository.Repository;
 
 public interface EquipmentRepository extends Repository<Equipment, Long> {
@@ -8,4 +10,6 @@ public interface EquipmentRepository extends Repository<Equipment, Long> {
     Equipment save(Equipment equipment);
 
     Optional<Equipment> findById(Long id);
+
+    Slice<Equipment> findEquipmentsBy(Pageable pageable);
 }

--- a/src/main/java/com/girigiri/kwrental/equipment/controller/EquipmentController.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/controller/EquipmentController.java
@@ -1,24 +1,53 @@
 package com.girigiri.kwrental.equipment.controller;
 
 import com.girigiri.kwrental.equipment.dto.EquipmentDetailResponse;
+import com.girigiri.kwrental.equipment.dto.EquipmentResponse;
+import com.girigiri.kwrental.equipment.dto.EquipmentsPageResponse;
 import com.girigiri.kwrental.equipment.service.EquipmentService;
+import com.girigiri.kwrental.util.LinkUtils;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequestMapping("/api/equipments")
 public class EquipmentController {
 
     private final EquipmentService equipmentService;
+    private final LinkUtils linkUtils;
 
-    public EquipmentController(final EquipmentService equipmentService) {
+    public EquipmentController(final EquipmentService equipmentService, final LinkUtils linkUtils) {
         this.equipmentService = equipmentService;
+        this.linkUtils = linkUtils;
     }
 
     @GetMapping("/{id}")
     public EquipmentDetailResponse getEquipment(@PathVariable final Long id) {
         return equipmentService.findById(id);
+    }
+
+    @GetMapping
+    public EquipmentsPageResponse getEquipmentsPage(
+            @PageableDefault(sort = {"id"}, direction = Direction.DESC) Pageable pageable) {
+
+        final UriComponentsBuilder builder = MvcUriComponentsBuilder.fromMethodName(
+                EquipmentController.class, "getEquipmentsPage", pageable);
+
+        final Slice<EquipmentResponse> equipments = equipmentService.findEquipmentsBy(pageable);
+
+        String nextLink = linkUtils.createIfNextExists(equipments, builder);
+        String previousLink = linkUtils.createIfPreviousExists(equipments, builder);
+        return EquipmentsPageResponse.builder()
+                .nextLink(nextLink).previousLink(previousLink)
+                .page(pageable.getPageNumber())
+                .items(equipments.getContent())
+                .build();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/equipment/dto/EquipmentResponse.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/dto/EquipmentResponse.java
@@ -1,0 +1,25 @@
+package com.girigiri.kwrental.equipment.dto;
+
+import com.girigiri.kwrental.equipment.Equipment;
+import lombok.Builder;
+
+@Builder
+public record EquipmentResponse(
+        Long id,
+        String category,
+        String maker,
+        String modelName,
+        RentalQuantityResponse rentalQuantity,
+        String imgUrl
+) {
+    public static EquipmentResponse from(final Equipment equipment) {
+        return EquipmentResponse.builder()
+                .id(equipment.getId())
+                .category(equipment.getCategory().name())
+                .maker(equipment.getMaker())
+                .modelName(equipment.getModelName())
+                .rentalQuantity(RentalQuantityResponse.from(equipment.getRentalQuantity()))
+                .imgUrl(equipment.getImgUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/equipment/dto/EquipmentsPageResponse.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/dto/EquipmentsPageResponse.java
@@ -1,0 +1,13 @@
+package com.girigiri.kwrental.equipment.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record EquipmentsPageResponse(
+        String nextLink,
+        String previousLink,
+        Integer page,
+        List<EquipmentResponse> items
+) {
+}

--- a/src/main/java/com/girigiri/kwrental/equipment/service/EquipmentService.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/service/EquipmentService.java
@@ -3,7 +3,10 @@ package com.girigiri.kwrental.equipment.service;
 import com.girigiri.kwrental.equipment.Equipment;
 import com.girigiri.kwrental.equipment.EquipmentRepository;
 import com.girigiri.kwrental.equipment.dto.EquipmentDetailResponse;
+import com.girigiri.kwrental.equipment.dto.EquipmentResponse;
 import com.girigiri.kwrental.equipment.exception.EquipmentNotFoundException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,5 +24,11 @@ public class EquipmentService {
         final Equipment equipment = equipmentRepository.findById(id)
                 .orElseThrow(EquipmentNotFoundException::new);
         return EquipmentDetailResponse.from(equipment);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<EquipmentResponse> findEquipmentsBy(final Pageable pageable) {
+        return equipmentRepository.findEquipmentsBy(pageable)
+                .map(EquipmentResponse::from);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/util/LinkUtils.java
+++ b/src/main/java/com/girigiri/kwrental/util/LinkUtils.java
@@ -1,0 +1,45 @@
+package com.girigiri.kwrental.util;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class LinkUtils {
+
+    public String createIfNextExists(final Slice<?> slice, final UriComponentsBuilder builder) {
+        if (slice.hasNext()) {
+            return addPageableParameters(builder, slice.nextPageable());
+        }
+        return null;
+    }
+
+    public String createIfPreviousExists(final Slice<?> slice, final UriComponentsBuilder builder) {
+        if (slice.hasPrevious()) {
+            return addPageableParameters(builder, slice.previousPageable());
+        }
+        return null;
+    }
+
+    private String addPageableParameters(final UriComponentsBuilder builder, final Pageable pageable) {
+        return builder
+                .queryParam("size", pageable.getPageSize())
+                .queryParam("page", pageable.getPageNumber())
+                .queryParam("sort", sortToString(pageable.getSort()))
+                .build().toUriString();
+    }
+
+    private String sortToString(final Sort sort) {
+        StringBuilder builder = new StringBuilder();
+
+        for (Order order : sort) {
+            builder.append("&sort=").append(order.getProperty())
+                    .append(",").append(order.getDirection().name());
+        }
+        builder.delete(0, 6);
+        return builder.toString();
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/acceptance/TestFixtures.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/TestFixtures.java
@@ -6,6 +6,7 @@ import com.girigiri.kwrental.equipment.RentalDays;
 import com.girigiri.kwrental.equipment.RentalQuantity;
 import com.girigiri.kwrental.equipment.RentalTimes;
 import com.girigiri.kwrental.equipment.dto.EquipmentDetailResponse;
+import com.girigiri.kwrental.equipment.dto.EquipmentResponse;
 import com.girigiri.kwrental.equipment.dto.RentalDaysResponse;
 import com.girigiri.kwrental.equipment.dto.RentalQuantityResponse;
 import com.girigiri.kwrental.equipment.dto.RentalTimesResponse;
@@ -47,7 +48,7 @@ public class TestFixtures {
                 .build();
     }
 
-    public static EquipmentDetailResponse createEquipmentResponse() {
+    public static EquipmentDetailResponse createEquipmentDetailResponse() {
         return EquipmentDetailResponse.builder()
                 .modelName(modelName)
                 .category(Category.CAMERA.name())
@@ -62,4 +63,15 @@ public class TestFixtures {
                 .rentalDays(RentalDaysResponse.from(rentalDays))
                 .build();
     }
+
+    public static EquipmentResponse createEquipmentResponse() {
+        return EquipmentResponse.builder()
+                .modelName(modelName)
+                .category(Category.CAMERA.name())
+                .maker(maker)
+                .imgUrl(imgUrl)
+                .rentalQuantity(RentalQuantityResponse.from(rentalQuantity))
+                .build();
+    }
+
 }

--- a/src/test/java/com/girigiri/kwrental/equipment/controller/EquipmentControllerTest.java
+++ b/src/test/java/com/girigiri/kwrental/equipment/controller/EquipmentControllerTest.java
@@ -5,15 +5,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.girigiri.kwrental.equipment.exception.EquipmentNotFoundException;
 import com.girigiri.kwrental.equipment.service.EquipmentService;
+import com.girigiri.kwrental.util.LinkUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {EquipmentController.class})
+@Import({LinkUtils.class})
 class EquipmentControllerTest {
 
     @Autowired

--- a/src/test/java/com/girigiri/kwrental/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/equipment/service/EquipmentServiceTest.java
@@ -2,17 +2,22 @@ package com.girigiri.kwrental.equipment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.girigiri.kwrental.acceptance.TestFixtures;
 import com.girigiri.kwrental.equipment.Equipment;
 import com.girigiri.kwrental.equipment.EquipmentRepository;
 import com.girigiri.kwrental.equipment.dto.EquipmentDetailResponse;
+import com.girigiri.kwrental.equipment.dto.EquipmentResponse;
 import com.girigiri.kwrental.equipment.exception.EquipmentNotFoundException;
 import com.girigiri.kwrental.support.ResetDatabaseTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 
 @SpringBootTest
 class EquipmentServiceTest extends ResetDatabaseTest {
@@ -34,7 +39,7 @@ class EquipmentServiceTest extends ResetDatabaseTest {
 
         // then
         assertThat(response).usingRecursiveComparison().ignoringFields("id")
-                .isEqualTo(TestFixtures.createEquipmentResponse());
+                .isEqualTo(TestFixtures.createEquipmentDetailResponse());
     }
 
     @Test
@@ -43,5 +48,26 @@ class EquipmentServiceTest extends ResetDatabaseTest {
         // given, when, then
         assertThatThrownBy(() -> equipmentService.findById(1L))
                 .isExactlyInstanceOf(EquipmentNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("등록된 기자재들을 페이지로 조회할 수 있다.")
+    void findEquipmentsBy() {
+        // given
+        equipmentRepository.save(TestFixtures.createEquipment());
+        equipmentRepository.save(TestFixtures.createEquipment());
+        equipmentRepository.save(TestFixtures.createEquipment());
+
+        // when
+        final Slice<EquipmentResponse> expect = equipmentService.findEquipmentsBy(
+                PageRequest.of(1, 1, Sort.by("id").descending()));
+
+        // then
+        assertAll(
+                () -> assertThat(expect.hasNext()).isTrue(),
+                () -> assertThat(expect.hasPrevious()).isTrue(),
+                () -> assertThat(expect.getContent()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                        .containsExactly(TestFixtures.createEquipmentResponse())
+        );
     }
 }

--- a/src/test/java/com/girigiri/kwrental/util/LinkUtilsTest.java
+++ b/src/test/java/com/girigiri/kwrental/util/LinkUtilsTest.java
@@ -1,0 +1,47 @@
+package com.girigiri.kwrental.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.util.UriComponentsBuilder;
+
+class LinkUtilsTest {
+
+    private final LinkUtils linkUtils = new LinkUtils();
+    private final UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/example");
+
+    @Test
+    @DisplayName("다음 페이지가 존재하는 경우 링크를 생성한다.")
+    void createIfNextExists() {
+        // given
+        final SliceImpl<Integer> slice = new SliceImpl<>(List.of(1, 2, 3),
+                PageRequest.of(0, 3, Sort.by("value").descending()), true);
+
+        // when
+        final String expect = linkUtils.createIfNextExists(slice, builder);
+
+        // then
+        assertThat(expect).isNotNull()
+                .contains("?size=3&page=1&sort=value,DESC");
+    }
+
+    @Test
+    @DisplayName("이전 페이지가 존재하는 경우 링크를 생성한다.")
+    void createIfPreviousExists() {
+        // given
+        final SliceImpl<Integer> slice = new SliceImpl<>(List.of(1, 2, 3),
+                PageRequest.of(1, 3, Sort.by("value").descending()), true);
+
+        // when
+        final String expect = linkUtils.createIfPreviousExists(slice, builder);
+
+        // then
+        assertThat(expect).isNotNull()
+                .contains("?size=3&page=0&sort=value,DESC");
+    }
+}


### PR DESCRIPTION
# 주요 구현 내용
- 추후에 페이징 구현 방식이 달라짐에 따라 요청하는 URI가 달라지게 된다. 이런 변경을 최소화하기 위해 첫 페이지 접근만 클라이언트에게 공유하고 그 다음 이동부터는 응답 메시지에 담긴 링크를 통해 이동하도록 구현했다.
- 아칙 최적화가 필요한 단계는 아니라서 오프셋 페이징 방법을 적용했다. 만약 데이터가 매우 큰 도메인에서 페이징을 적용해야 할 때 변경하기로 한다.
- 링크를 생성할 때 다음(혹은 이전) 페이지의 유무에 따라 링크를 보내주거나 null을 보내주도록 햇다. 이런 로직을 컨트롤러 대신 다른 유틸성 컴포넌트로 빼서 사용햇다.