### PR TITLE
CORS를 허용한다.

### DIFF
--- a/src/main/java/com/girigiri/kwrental/config/WebConfig.java
+++ b/src/main/java/com/girigiri/kwrental/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.girigiri.kwrental.config;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.TRACE;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedMethods(GET.name(), OPTIONS.name(), POST.name(), DELETE.name(),
+                        PUT.name(), HEAD.name(), PATCH.name(), TRACE.name());
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/equipment/controller/EquipmentController.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/controller/EquipmentController.java
@@ -21,11 +21,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class EquipmentController {
 
     private final EquipmentService equipmentService;
-    private final LinkUtils linkUtils;
 
-    public EquipmentController(final EquipmentService equipmentService, final LinkUtils linkUtils) {
+    public EquipmentController(final EquipmentService equipmentService) {
         this.equipmentService = equipmentService;
-        this.linkUtils = linkUtils;
     }
 
     @GetMapping("/{id}")
@@ -42,8 +40,8 @@ public class EquipmentController {
 
         final Slice<EquipmentResponse> equipments = equipmentService.findEquipmentsBy(pageable);
 
-        String nextLink = linkUtils.createIfNextExists(equipments, builder);
-        String previousLink = linkUtils.createIfPreviousExists(equipments, builder);
+        String nextLink = LinkUtils.createIfNextExists(equipments, builder);
+        String previousLink = LinkUtils.createIfPreviousExists(equipments, builder);
         return EquipmentsPageResponse.builder()
                 .nextLink(nextLink).previousLink(previousLink)
                 .page(pageable.getPageNumber())

--- a/src/main/java/com/girigiri/kwrental/util/LinkUtils.java
+++ b/src/main/java/com/girigiri/kwrental/util/LinkUtils.java
@@ -10,21 +10,21 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Component
 public class LinkUtils {
 
-    public String createIfNextExists(final Slice<?> slice, final UriComponentsBuilder builder) {
+    public static String createIfNextExists(final Slice<?> slice, final UriComponentsBuilder builder) {
         if (slice.hasNext()) {
             return addPageableParameters(builder, slice.nextPageable());
         }
         return null;
     }
 
-    public String createIfPreviousExists(final Slice<?> slice, final UriComponentsBuilder builder) {
+    public static String createIfPreviousExists(final Slice<?> slice, final UriComponentsBuilder builder) {
         if (slice.hasPrevious()) {
             return addPageableParameters(builder, slice.previousPageable());
         }
         return null;
     }
 
-    private String addPageableParameters(final UriComponentsBuilder builder, final Pageable pageable) {
+    private static String addPageableParameters(final UriComponentsBuilder builder, final Pageable pageable) {
         return builder
                 .queryParam("size", pageable.getPageSize())
                 .queryParam("page", pageable.getPageNumber())
@@ -32,7 +32,7 @@ public class LinkUtils {
                 .build().toUriString();
     }
 
-    private String sortToString(final Sort sort) {
+    private static String sortToString(final Sort sort) {
         StringBuilder builder = new StringBuilder();
 
         for (Order order : sort) {

--- a/src/test/java/com/girigiri/kwrental/config/WebConfigTest.java
+++ b/src/test/java/com/girigiri/kwrental/config/WebConfigTest.java
@@ -5,22 +5,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.girigiri.kwrental.equipment.service.EquipmentService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest
+@SpringBootTest
+@AutoConfigureMockMvc
 class WebConfigTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
-    private EquipmentService equipmentService;
 
     @Test
     @DisplayName("URI가 /api/**인 요청에 CORS를 허용한다.")

--- a/src/test/java/com/girigiri/kwrental/config/WebConfigTest.java
+++ b/src/test/java/com/girigiri/kwrental/config/WebConfigTest.java
@@ -1,0 +1,40 @@
+package com.girigiri.kwrental.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.girigiri.kwrental.equipment.service.EquipmentService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest
+class WebConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EquipmentService equipmentService;
+
+    @Test
+    @DisplayName("URI가 /api/**인 요청에 CORS를 허용한다.")
+    void allowCors() throws Exception {
+        // given, when
+        mockMvc.perform(options("/api")
+                        .header("Access-Control-Request-Method", "GET")
+                        .header("Origin", "http://some-origin:1234"))
+
+                //then
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(header().string("Access-Control-Allow-Origin", "*"))
+                .andExpect(header().string("Access-Control-Allow-Methods",
+                        "GET,OPTIONS,POST,DELETE,PUT,HEAD,PATCH,TRACE"))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/equipment/controller/EquipmentControllerTest.java
+++ b/src/test/java/com/girigiri/kwrental/equipment/controller/EquipmentControllerTest.java
@@ -5,18 +5,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.girigiri.kwrental.equipment.exception.EquipmentNotFoundException;
 import com.girigiri.kwrental.equipment.service.EquipmentService;
-import com.girigiri.kwrental.util.LinkUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {EquipmentController.class})
-@Import({LinkUtils.class})
 class EquipmentControllerTest {
 
     @Autowired


### PR DESCRIPTION
# 주요 구현 내용
- WebMvcConfigurer를 구현한 설정파일을 만들어서 `/api`로 시작하는 모든 URI에 모든 HTTP 메서드의 요청을 허용했다.
- `@AutoConfigureMockMvc`와 `@SpringBootTest`를 활용해서 테스트했다.
- `@WebMvcTest`로 테스트 하려고 했는데 이럴 경우 컨트롤러가 의존하는 빈객체를 MockBean으로 선언해줘야 되는 점이 불필요하게 느껴져서 선택하지 않았다.
- 크레덴셜과 max-age 관련은 아직 설정해줄 필요가 없게 느껴져서 해주지 않았다.
## 기타 추가 수정
- LinkUtils를 빈 객체로 주입받는게 아니라 정적 메서드로 활용하기로 했다. `@WebMvcTest`를 할 때 MockBean으로 처리해줘야 하는 게 불편했기 때문이다.

# 참고자료
https://www.baeldung.com/spring-cors
https://spring.io/guides/gs/rest-service-cors/