### PR TITLE
쿼리파라미터 시작 전 슬래시 제거

### DIFF
--- a/src/main/java/com/girigiri/kwrental/util/LinkUtils.java
+++ b/src/main/java/com/girigiri/kwrental/util/LinkUtils.java
@@ -29,7 +29,7 @@ public class LinkUtils {
                 .queryParam("size", pageable.getPageSize())
                 .queryParam("page", pageable.getPageNumber())
                 .queryParam("sort", sortToString(pageable.getSort()))
-                .build().toUriString();
+                .build().toUriString().replaceFirst("/\\?", "?");
     }
 
     private String sortToString(final Sort sort) {

--- a/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
@@ -82,7 +82,7 @@ class EquipmentAcceptanceTest extends ResetDatabaseTest {
 
         // then
         assertAll(
-                () -> assertThat(response.nextLink()).contains("/api/equipments/?size=2&page=1&sort=id,DESC"),
+                () -> assertThat(response.nextLink()).contains("/api/equipments?size=2&page=1&sort=id,DESC"),
                 () -> assertThat(response.previousLink()).isNull(),
                 () -> assertThat(response.items()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
                         .containsExactly(TestFixtures.createEquipmentResponse(), TestFixtures.createEquipmentResponse())


### PR DESCRIPTION
컨트롤러에 매핑된 URI를 가져오기 위해 사용한 UriComponentBuilder는 항상 마지막에 슬래시를 붙인다. 그래서 여기에 그냥 파라미터를 추가하면 `api/equipments/?size=2` 이렇게 슬래시와 물음표가 같이 적힌다.
문제는 스프링에서  물음표 이전에 슬래시 유무에 따라 다른 URI라고 판단해서 슬래시가 있는 경우는 매핑할 수 없으므로 404를 반환하는 문제가 있었다. 그래서 컨트롤러 매핑 URI에 슬래시를 넣어주던지 아니면 UriComponentBuilder의 결과물에서 슬래시를 지워주던지 해야했다.

나는 그 동안 슬래시를 계속 생략하는 방식이 익숙하고 API 설계또 슬래시를 생략하는 방식으로 설계돼서 슬래시를 생략하는 방향으로 구현했다. 