### PR TITLE
Spring Rest Docs로 API를 문서화 한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ asciidoctor {
 
 bootJar {
     dependsOn asciidoctor
-    from("${asciidoctor.outputDir}/html5") {
+    from("${asciidoctor.outputDir}/") {
         into 'static/docs'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.2'
     id 'io.spring.dependency-management' version '1.1.0'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id 'com.epages.restdocs-api-spec' version '0.16.0'
 }
 
 group = 'com.girigiri'
@@ -12,6 +14,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -27,8 +30,43 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured'
+
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+    implementation 'com.epages:restdocs-api-spec-restassured:0.16.0'
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
 }
 
 tasks.named('test') {
+    outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy asciidoctor
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    sources {
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile()
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
+}
+
+openapi3 {
+    server = 'https://localhost:8080'
+    title = 'KW-GIRIGIRI API'
+    description = 'KW-GIRIGIRI backend API spec.'
+    version = '0.1.0'
+    format = 'yaml'
 }

--- a/src/docs/asciidoc/equipment.adoc
+++ b/src/docs/asciidoc/equipment.adoc
@@ -1,0 +1,9 @@
+== 기자재 관련 API
+
+=== 기자재 상세 조회
+
+operation::getEquipment[snippets='http-request,http-response']
+
+=== 기자재 목록 페이지 조회
+
+operation::getEquipmentsPage[snippets='http-request,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,8 @@
+:doctype: book
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+= KW - GIRIGIRI
+
+include::equipment.adoc[]

--- a/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.girigiri.kwrental.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
 
@@ -45,8 +46,11 @@ class EquipmentAcceptanceTest extends ResetDatabaseTest {
     @BeforeEach
     void setUp(RestDocumentationContextProvider restDocumentation) {
         RestAssured.port = port;
+        RestAssured.requestSpecification = this.requestSpec;
         this.requestSpec = new RequestSpecBuilder()
-                .addFilter(documentationConfiguration(restDocumentation))
+                .addFilter(documentationConfiguration(restDocumentation).operationPreprocessors()
+                        .withResponseDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
                 .build();
     }
 

--- a/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
@@ -2,6 +2,8 @@ package com.girigiri.kwrental.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
 
 import com.girigiri.kwrental.equipment.Equipment;
 import com.girigiri.kwrental.equipment.EquipmentRepository;
@@ -10,21 +12,29 @@ import com.girigiri.kwrental.equipment.dto.EquipmentsPageResponse;
 import com.girigiri.kwrental.support.DatabaseCleanUp;
 import com.girigiri.kwrental.support.ResetDatabaseTest;
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ExtendWith(RestDocumentationExtension.class)
 class EquipmentAcceptanceTest extends ResetDatabaseTest {
 
     @LocalServerPort
     private int port;
+
+    private RequestSpecification requestSpec;
 
     @Autowired
     private EquipmentRepository equipmentRepository;
@@ -33,8 +43,11 @@ class EquipmentAcceptanceTest extends ResetDatabaseTest {
     private DatabaseCleanUp databaseCleanUp;
 
     @BeforeEach
-    void setUp() {
+    void setUp(RestDocumentationContextProvider restDocumentation) {
         RestAssured.port = port;
+        this.requestSpec = new RequestSpecBuilder()
+                .addFilter(documentationConfiguration(restDocumentation))
+                .build();
     }
 
     @AfterEach
@@ -50,7 +63,8 @@ class EquipmentAcceptanceTest extends ResetDatabaseTest {
         equipmentRepository.save(equipment);
 
         // when
-        final EquipmentDetailResponse response = RestAssured.given()
+        final EquipmentDetailResponse response = RestAssured.given(this.requestSpec)
+                .filter(document("getEquipment"))
                 .when().get("/api/equipments/{id}", equipment.getId())
                 .then().statusCode(HttpStatus.OK.value()).log().all()
                 .and().extract().as(EquipmentDetailResponse.class);
@@ -75,7 +89,8 @@ class EquipmentAcceptanceTest extends ResetDatabaseTest {
         equipmentRepository.save(equipment4);
 
         // when
-        final EquipmentsPageResponse response = RestAssured.given()
+        final EquipmentsPageResponse response = RestAssured.given(this.requestSpec)
+                .filter(document("getEquipmentsPage"))
                 .when().get("/api/equipments?size=2")
                 .then().statusCode(HttpStatus.OK.value()).log().all()
                 .and().extract().as(EquipmentsPageResponse.class);


### PR DESCRIPTION
# 주요 구현 내용
Spirng Rest Docs로 APi 문서화 하였다.
`{origin}/docs/index.html`하면 API 문서에 접근할 수 있다.

# 참고 자료
https://docs.spring.io/spring-restdocs/docs/current/reference/htmlsingle/
https://spring.io/guides/gs/testing-restdocs/
https://www.baeldung.com/spring-rest-docs