### PR TITLE
기자재 정보 수정 및 기자재 품목들 수정 API 구현

### DIFF
--- a/src/docs/asciidoc/equipment.adoc
+++ b/src/docs/asciidoc/equipment.adoc
@@ -31,3 +31,9 @@ operation::admin_deleteEquipment[snippets='http-request,http-response']
 ==== Location 헤더에 접근 가능한 URL이 담긴다.
 
 operation::admin_uploadImage[snippets='http-request,http-response']
+
+=== 기자재 정보 수정
+
+==== Location 헤더에 수정된 기자재 정보로 접근할 수 있다.
+
+operation::admin_updateEquipment[snippets='http-request,http-response']

--- a/src/docs/asciidoc/item.adoc
+++ b/src/docs/asciidoc/item.adoc
@@ -15,3 +15,9 @@ operation::admin_updateRentalAvailable[snippets='http-request,http-response']
 === 관리자 품목 자산 번호 변경 API
 
 operation::admin_updatePropertyNumber[snippets='http-request,http-response']
+
+=== 관리자 기자재 품목들 수정 API
+
+==== `id` 값이 null이면 품목이 추가된다. `id` 값이 null이 아니면 전달받은 값으로 수정한다.
+
+operation::admin_updateItemsByEquipment[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/GlobalExceptionAdvice.java
+++ b/src/main/java/com/girigiri/kwrental/GlobalExceptionAdvice.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.ObjectError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -78,6 +79,11 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<?> handleConstraintViolation(final ConstraintViolationException e) {
         return ResponseEntity.badRequest().body("입력값 검증을 통과하지 못했습니다." + e.getMessage());
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<?> handleHttpMethodNotSupported() {
+        return ResponseEntity.badRequest().body("해당 HTTP METHOD는 처리할 수 없습니다.");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/girigiri/kwrental/GlobalExceptionAdvice.java
+++ b/src/main/java/com/girigiri/kwrental/GlobalExceptionAdvice.java
@@ -3,7 +3,7 @@ package com.girigiri.kwrental;
 import com.amazonaws.AmazonServiceException;
 import com.girigiri.kwrental.common.exception.BadRequestException;
 import com.girigiri.kwrental.common.exception.NotFoundException;
-import com.girigiri.kwrental.equipment.exception.EquipmentException;
+import jakarta.persistence.PersistenceException;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -50,7 +50,7 @@ public class GlobalExceptionAdvice {
                 .body("데이터베이스에 잘못된 접근입니다.");
     }
 
-    @ExceptionHandler(DataIntegrityViolationException.class)
+    @ExceptionHandler({DataIntegrityViolationException.class, PersistenceException.class})
     public ResponseEntity<?> handleDataIntegrityViolation() {
         return ResponseEntity.badRequest()
                 .body("데이터의 조건이 맞지 않습니다. 유일값이나 null 조건을 확인하세요.");
@@ -59,11 +59,6 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(DuplicateKeyException.class)
     public ResponseEntity<?> handleDuplicateKey() {
         return ResponseEntity.badRequest().body("중복되서는 안되는 값이 중복된 요청입니다.");
-    }
-
-    @ExceptionHandler(EquipmentException.class)
-    public ResponseEntity<?> handleEquipmentException(final EquipmentException e) {
-        return ResponseEntity.badRequest().body(e.getMessage());
     }
 
     @ExceptionHandler(AmazonServiceException.class)

--- a/src/main/java/com/girigiri/kwrental/common/exception/DomainException.java
+++ b/src/main/java/com/girigiri/kwrental/common/exception/DomainException.java
@@ -1,0 +1,7 @@
+package com.girigiri.kwrental.common.exception;
+
+public class DomainException extends BadRequestException {
+    public DomainException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/equipment/controller/AdminEquipmentController.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/controller/AdminEquipmentController.java
@@ -3,6 +3,8 @@ package com.girigiri.kwrental.equipment.controller;
 import com.girigiri.kwrental.common.MultiPartFileHandler;
 import com.girigiri.kwrental.equipment.dto.request.AddEquipmentWithItemsRequest;
 import com.girigiri.kwrental.equipment.dto.request.EquipmentSearchCondition;
+import com.girigiri.kwrental.equipment.dto.request.UpdateEquipmentRequest;
+import com.girigiri.kwrental.equipment.dto.response.EquipmentDetailResponse;
 import com.girigiri.kwrental.equipment.dto.response.EquipmentPageResponse;
 import com.girigiri.kwrental.equipment.dto.response.SimpleEquipmentResponse;
 import com.girigiri.kwrental.equipment.exception.EquipmentException;
@@ -79,6 +81,14 @@ public class AdminEquipmentController {
         URL url = multiPartFileHandler.upload(multipartFile);
         return ResponseEntity.noContent()
                 .location(url.toURI())
+                .build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable final Long id, @Validated @RequestBody final UpdateEquipmentRequest updateEquipmentRequest) {
+        EquipmentDetailResponse updatedResponse = equipmentService.update(id, updateEquipmentRequest);
+        return ResponseEntity.noContent()
+                .location(URI.create("/api/equipments/" + updatedResponse.id()))
                 .build();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/equipment/domain/Equipment.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/domain/Equipment.java
@@ -3,9 +3,11 @@ package com.girigiri.kwrental.equipment.domain;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Entity
+@Setter
 public class Equipment {
 
     @Id

--- a/src/main/java/com/girigiri/kwrental/equipment/dto/request/UpdateEquipmentRequest.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/dto/request/UpdateEquipmentRequest.java
@@ -1,0 +1,13 @@
+package com.girigiri.kwrental.equipment.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import org.hibernate.validator.constraints.Length;
+
+public record UpdateEquipmentRequest(
+        @NotEmpty String rentalDays, @NotEmpty String modelName, @NotEmpty String category,
+        @NotEmpty String maker, @NotEmpty String imgUrl, @Length(max = 200) String component,
+        @Length(max = 100) String purpose, @Length(max = 500) String description, @Positive Integer totalQuantity,
+        @Positive Integer maxRentalDays) {
+
+}

--- a/src/main/java/com/girigiri/kwrental/equipment/exception/EquipmentException.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/exception/EquipmentException.java
@@ -1,6 +1,8 @@
 package com.girigiri.kwrental.equipment.exception;
 
-public class EquipmentException extends RuntimeException {
+import com.girigiri.kwrental.common.exception.DomainException;
+
+public class EquipmentException extends DomainException {
 
     public EquipmentException(final String message) {
         super(message);

--- a/src/main/java/com/girigiri/kwrental/equipment/exception/RentalQuantityException.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/exception/RentalQuantityException.java
@@ -1,6 +1,8 @@
 package com.girigiri.kwrental.equipment.exception;
 
-public class RentalQuantityException extends RuntimeException {
+import com.girigiri.kwrental.common.exception.DomainException;
+
+public class RentalQuantityException extends DomainException {
     public RentalQuantityException(final String message) {
         super(message);
     }

--- a/src/main/java/com/girigiri/kwrental/equipment/service/EquipmentService.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/service/EquipmentService.java
@@ -5,6 +5,7 @@ import com.girigiri.kwrental.equipment.domain.Equipment;
 import com.girigiri.kwrental.equipment.dto.request.AddEquipmentRequest;
 import com.girigiri.kwrental.equipment.dto.request.AddEquipmentWithItemsRequest;
 import com.girigiri.kwrental.equipment.dto.request.EquipmentSearchCondition;
+import com.girigiri.kwrental.equipment.dto.request.UpdateEquipmentRequest;
 import com.girigiri.kwrental.equipment.dto.response.EquipmentDetailResponse;
 import com.girigiri.kwrental.equipment.dto.response.SimpleEquipmentResponse;
 import com.girigiri.kwrental.equipment.dto.response.SimpleEquipmentWithRentalQuantityResponse;
@@ -82,5 +83,23 @@ public class EquipmentService {
                 .orElseThrow(EquipmentNotFoundException::new);
         equipmentRepository.deleteById(id);
         eventPublisher.publishEvent(new EquipmentDeleteEvent(this, id));
+    }
+
+    @Transactional
+    public EquipmentDetailResponse update(final Long id, final UpdateEquipmentRequest updateEquipmentRequest) {
+        Equipment equipment = equipmentRepository.findById(id)
+                .orElseThrow(EquipmentNotFoundException::new);
+
+        equipment.setModelName(updateEquipmentRequest.modelName());
+        equipment.setComponents(updateEquipmentRequest.component());
+        equipment.setCategory(Category.from(updateEquipmentRequest.category()));
+        equipment.setMaker(updateEquipmentRequest.maker());
+        equipment.setDescription(updateEquipmentRequest.description());
+        equipment.setPurpose(updateEquipmentRequest.purpose());
+        equipment.setImgUrl(updateEquipmentRequest.imgUrl());
+        equipment.setRentalPlace(updateEquipmentRequest.rentalDays());
+        equipment.setMaxRentalDays(updateEquipmentRequest.maxRentalDays());
+        equipment.setTotalQuantity(updateEquipmentRequest.totalQuantity());
+        return EquipmentDetailResponse.from(equipment);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/item/controller/AdminItemController.java
+++ b/src/main/java/com/girigiri/kwrental/item/controller/AdminItemController.java
@@ -2,9 +2,13 @@ package com.girigiri.kwrental.item.controller;
 
 import com.girigiri.kwrental.item.dto.request.ItemPropertyNumberRequest;
 import com.girigiri.kwrental.item.dto.request.ItemRentalAvailableRequest;
+import com.girigiri.kwrental.item.dto.request.UpdateItemsRequest;
 import com.girigiri.kwrental.item.service.ItemServiceImpl;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/admin/items")
@@ -34,5 +38,11 @@ public class AdminItemController {
     public ResponseEntity<?> delete(@PathVariable final Long id) {
         itemService.delete(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping
+    public ResponseEntity<?> saveOrUpdate(final Long equipmentId, @RequestBody @Validated UpdateItemsRequest updateItemsRequest) {
+        itemService.saveOrUpdate(equipmentId, updateItemsRequest);
+        return ResponseEntity.noContent().location(URI.create("/api/items?equipmentId=" + equipmentId)).build();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/item/domain/EquipmentItems.java
+++ b/src/main/java/com/girigiri/kwrental/item/domain/EquipmentItems.java
@@ -1,0 +1,57 @@
+package com.girigiri.kwrental.item.domain;
+
+import com.girigiri.kwrental.item.exception.EquipmentItemsException;
+import com.girigiri.kwrental.item.exception.ItemNotFoundException;
+
+import java.util.*;
+
+public class EquipmentItems {
+
+    private final Map<Long, Item> items;
+
+    private EquipmentItems(Map<Long, Item> items) {
+        this.items = items;
+    }
+
+    public static EquipmentItems from(List<Item> inputItems) {
+        Map<Long, Item> items = new HashMap<>();
+        Set<String> propertyNumberSet = new HashSet<>();
+        for (Item item : inputItems) {
+            validateId(items, item);
+            validatePropertyNumber(propertyNumberSet, item);
+            items.put(item.getId(), item);
+            propertyNumberSet.add(item.getPropertyNumber());
+        }
+        return new EquipmentItems(items);
+    }
+
+    private static void validatePropertyNumber(Set<String> propertyNumberSet, Item item) {
+        if (item.getPropertyNumber() == null) {
+            throw new EquipmentItemsException("기자재의 품목 중 자산 번호가 null인 품목이 존재합니다.");
+        }
+        if (propertyNumberSet.contains(item.getPropertyNumber())) {
+            throw new EquipmentItemsException("기자재의 품목 중 자산 번호가 중복된 품목이 존재합니다.");
+        }
+    }
+
+    private static void validateId(Map<Long, Item> items, Item item) {
+        if (item.getId() == null) {
+            throw new EquipmentItemsException("기자재의 품목 중 ID가 null인 품목이 존재합니다.");
+        }
+        if (items.containsKey(item.getId())) {
+            throw new EquipmentItemsException("기자재의 품목 중 ID가 중복된 품목이 존재합니다.");
+        }
+    }
+
+    public void updatePropertyNumberById(Long id, String propertyNumber) {
+        Item item = items.get(id);
+        if (item == null) {
+            throw new ItemNotFoundException();
+        }
+        item.updatePropertyNumber(propertyNumber);
+    }
+
+    public List<Item> getItems() {
+        return new ArrayList<>(items.values());
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/item/domain/Item.java
+++ b/src/main/java/com/girigiri/kwrental/item/domain/Item.java
@@ -1,5 +1,6 @@
 package com.girigiri.kwrental.item.domain;
 
+import com.girigiri.kwrental.item.exception.ItemException;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,5 +31,12 @@ public class Item {
         this.propertyNumber = propertyNumber;
         this.rentalAvailable = rentalAvailable;
         this.equipmentId = equipmentId;
+    }
+
+    public void updatePropertyNumber(String propertyNumber) {
+        if (propertyNumber == null || propertyNumber.isBlank()) {
+            throw new ItemException("자산 번호가 null이거나 빈 공백이면 안됩니다.");
+        }
+        this.propertyNumber = propertyNumber;
     }
 }

--- a/src/main/java/com/girigiri/kwrental/item/dto/request/UpdateItemRequest.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/request/UpdateItemRequest.java
@@ -1,4 +1,6 @@
 package com.girigiri.kwrental.item.dto.request;
 
-public record UpdateItemRequest(Long id, String propertyNumber) {
+import jakarta.validation.constraints.NotEmpty;
+
+public record UpdateItemRequest(Long id, @NotEmpty String propertyNumber) {
 }

--- a/src/main/java/com/girigiri/kwrental/item/dto/request/UpdateItemRequest.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/request/UpdateItemRequest.java
@@ -1,0 +1,4 @@
+package com.girigiri.kwrental.item.dto.request;
+
+public record UpdateItemRequest(Long id, String propertyNumber) {
+}

--- a/src/main/java/com/girigiri/kwrental/item/dto/request/UpdateItemsRequest.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/request/UpdateItemsRequest.java
@@ -1,8 +1,10 @@
 package com.girigiri.kwrental.item.dto.request;
 
+import jakarta.validation.Valid;
+
 import java.util.List;
 
 public record UpdateItemsRequest(
-        List<UpdateItemRequest> items
+        @Valid List<UpdateItemRequest> items
 ) {
 }

--- a/src/main/java/com/girigiri/kwrental/item/dto/request/UpdateItemsRequest.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/request/UpdateItemsRequest.java
@@ -1,0 +1,8 @@
+package com.girigiri.kwrental.item.dto.request;
+
+import java.util.List;
+
+public record UpdateItemsRequest(
+        List<UpdateItemRequest> items
+) {
+}

--- a/src/main/java/com/girigiri/kwrental/item/exception/EquipmentItemsException.java
+++ b/src/main/java/com/girigiri/kwrental/item/exception/EquipmentItemsException.java
@@ -1,0 +1,9 @@
+package com.girigiri.kwrental.item.exception;
+
+import com.girigiri.kwrental.common.exception.BadRequestException;
+
+public class EquipmentItemsException extends BadRequestException {
+    public EquipmentItemsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/item/exception/ItemException.java
+++ b/src/main/java/com/girigiri/kwrental/item/exception/ItemException.java
@@ -1,0 +1,9 @@
+package com.girigiri.kwrental.item.exception;
+
+import com.girigiri.kwrental.common.exception.DomainException;
+
+public class ItemException extends DomainException {
+    public ItemException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/girigiri/kwrental/item/service/ItemServiceImpl.java
@@ -4,9 +4,12 @@ import com.girigiri.kwrental.equipment.dto.request.AddItemRequest;
 import com.girigiri.kwrental.equipment.exception.EquipmentNotFoundException;
 import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
 import com.girigiri.kwrental.equipment.service.ItemService;
+import com.girigiri.kwrental.item.domain.EquipmentItems;
 import com.girigiri.kwrental.item.domain.Item;
 import com.girigiri.kwrental.item.dto.request.ItemPropertyNumberRequest;
 import com.girigiri.kwrental.item.dto.request.ItemRentalAvailableRequest;
+import com.girigiri.kwrental.item.dto.request.UpdateItemRequest;
+import com.girigiri.kwrental.item.dto.request.UpdateItemsRequest;
 import com.girigiri.kwrental.item.dto.response.ItemResponse;
 import com.girigiri.kwrental.item.dto.response.ItemsResponse;
 import com.girigiri.kwrental.item.exception.ItemNotFoundException;
@@ -15,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class ItemServiceImpl implements ItemService {
@@ -28,6 +33,7 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
+    @Transactional
     public void saveItems(final Long equipmentId, final List<AddItemRequest> itemRequests) {
         final List<Item> items = itemRequests.stream()
                 .map(it -> mapToItem(equipmentId, it))
@@ -77,5 +83,46 @@ public class ItemServiceImpl implements ItemService {
         itemRepository.findById(id)
                 .orElseThrow(ItemNotFoundException::new);
         itemRepository.deleteById(id);
+    }
+
+    @Transactional
+    public ItemsResponse updateOrSave(final Long equipmentId, final UpdateItemsRequest updateItemsRequest) {
+        Map<Boolean, List<UpdateItemRequest>> updateItemRequestsGroup = groupByIdNull(updateItemsRequest);
+        List<UpdateItemRequest> saveItemRequests = updateItemRequestsGroup.get(true);
+        save(equipmentId, saveItemRequests);
+
+        List<UpdateItemRequest> updateItemRequests = updateItemRequestsGroup.get(false);
+        List<Item> updatedItems = update(equipmentId, updateItemRequests);
+        return ItemsResponse.of(updatedItems);
+    }
+
+    private List<Item> update(Long equipmentId, List<UpdateItemRequest> updateItemRequests) {
+        List<Item> items = itemRepository.findByEquipmentId(equipmentId);
+        EquipmentItems equipmentItems = EquipmentItems.from(items);
+        for (UpdateItemRequest request : updateItemRequests) {
+            equipmentItems.updatePropertyNumberById(request.id(), request.propertyNumber());
+        }
+        return equipmentItems.getItems();
+    }
+
+    private Map<Boolean, List<UpdateItemRequest>> groupByIdNull(UpdateItemsRequest updateItemsRequest) {
+        return updateItemsRequest.items()
+                .stream()
+                .collect(Collectors.groupingBy(it -> it.id() == null));
+    }
+
+    private void save(final Long equipmentId, final List<UpdateItemRequest> saveItemRequests) {
+        List<Item> itemsToSave = saveItemRequests
+                .stream()
+                .map(it -> mapToItem(equipmentId, it))
+                .toList();
+        itemRepository.saveAll(itemsToSave);
+    }
+
+    private Item mapToItem(final Long equipmentId, final UpdateItemRequest updateItemRequest) {
+        return Item.builder()
+                .propertyNumber(updateItemRequest.propertyNumber())
+                .equipmentId(equipmentId)
+                .build();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/girigiri/kwrental/item/service/ItemServiceImpl.java
@@ -86,7 +86,7 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Transactional
-    public ItemsResponse updateOrSave(final Long equipmentId, final UpdateItemsRequest updateItemsRequest) {
+    public ItemsResponse saveOrUpdate(final Long equipmentId, final UpdateItemsRequest updateItemsRequest) {
         Map<Boolean, List<UpdateItemRequest>> updateItemRequestsGroup = groupByIdNull(updateItemsRequest);
         List<UpdateItemRequest> saveItemRequests = updateItemRequestsGroup.get(true);
         save(equipmentId, saveItemRequests);

--- a/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.girigiri.kwrental.equipment.domain.Equipment;
 import com.girigiri.kwrental.equipment.dto.request.AddEquipmentRequest;
 import com.girigiri.kwrental.equipment.dto.request.AddEquipmentWithItemsRequest;
 import com.girigiri.kwrental.equipment.dto.request.AddItemRequest;
+import com.girigiri.kwrental.equipment.dto.request.UpdateEquipmentRequest;
 import com.girigiri.kwrental.equipment.dto.response.*;
 import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
 import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
@@ -244,5 +245,27 @@ class EquipmentAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value())
                 .header(HttpHeaders.LOCATION, containsString(".png"));
+    }
+
+    @Test
+    @DisplayName("관리자가 기자재 수정 API")
+    void updateEquipmentAndItems() {
+        // given
+        Equipment equipment = equipmentRepository.save(EquipmentFixture.create());
+
+        UpdateEquipmentRequest updateEquipmentRequest = new UpdateEquipmentRequest(
+                "rentalDays", "modelName",
+                "CAMERA", "maker", "imgUrl",
+                "component", "purpose", "description", 1, 1);
+
+        // when
+        RestAssured.given(this.requestSpec)
+                .filter(document("admin_updateEquipment"))
+                .body(updateEquipmentRequest)
+                .contentType(ContentType.JSON)
+                .when().log().all().put("/api/admin/equipments/" + equipment.getId())
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value())
+                .header(HttpHeaders.LOCATION, containsString("/api/equipments/" + equipment.getId()));
     }
 }

--- a/src/test/java/com/girigiri/kwrental/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/equipment/service/EquipmentServiceTest.java
@@ -1,10 +1,7 @@
 package com.girigiri.kwrental.equipment.service;
 
 import com.girigiri.kwrental.equipment.domain.Equipment;
-import com.girigiri.kwrental.equipment.dto.request.AddEquipmentRequest;
-import com.girigiri.kwrental.equipment.dto.request.AddEquipmentWithItemsRequest;
-import com.girigiri.kwrental.equipment.dto.request.AddItemRequest;
-import com.girigiri.kwrental.equipment.dto.request.EquipmentSearchCondition;
+import com.girigiri.kwrental.equipment.dto.request.*;
 import com.girigiri.kwrental.equipment.dto.response.EquipmentDetailResponse;
 import com.girigiri.kwrental.equipment.dto.response.SimpleEquipmentResponse;
 import com.girigiri.kwrental.equipment.dto.response.SimpleEquipmentWithRentalQuantityResponse;
@@ -145,7 +142,7 @@ class EquipmentServiceTest {
     }
 
     @Test
-    @DisplayName("기자재 저장에서 잘못된 카테고리 예외 처리")
+    @DisplayName("기자재 저장에서 잘못된 카테고리 예외")
     void saveEquipment_invalidCategory() {
         // given
         AddEquipmentRequest addEquipmentRequest = new AddEquipmentRequest(
@@ -177,13 +174,47 @@ class EquipmentServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 기자재 삭제 예외 처리")
+    @DisplayName("존재하지 않는 기자재 삭제 예외")
     void deleteEquipment_notFound() {
         // given
         given(equipmentRepository.findById(1L)).willReturn(Optional.empty());
 
         // when
         assertThatThrownBy(() -> equipmentService.deleteEquipment(1L))
+                .isExactlyInstanceOf(EquipmentNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("기자재 수정 ")
+    void updateEquipment() {
+        // given
+        Equipment equipment = EquipmentFixture.create();
+        given(equipmentRepository.findById(any())).willReturn(Optional.of(equipment));
+        UpdateEquipmentRequest updateEquipmentRequest = new UpdateEquipmentRequest(
+                "updatedDays", "updatedName",
+                "ETC", "updatedMaker", "updatedImgUrl",
+                "updatedComponent", "updatedPurpose", "updatedDescription", 2, 2);
+
+        // when
+        EquipmentDetailResponse expect = equipmentService.update(1L, updateEquipmentRequest);
+
+        // then
+        assertThat(expect).usingRecursiveComparison()
+                .isEqualTo(EquipmentDetailResponse.from(equipment));
+    }
+
+    @Test
+    @DisplayName("존재하지 않은 기자재 수정 예외")
+    void updateEquipment_notFound() {
+        // given
+        given(equipmentRepository.findById(any())).willReturn(Optional.empty());
+        UpdateEquipmentRequest updateEquipmentRequest = new UpdateEquipmentRequest(
+                "rentalDays", "modelName",
+                "CAMERA", "maker", "imgUrl",
+                "component", "purpose", "description", 1, 2);
+
+        // when, then
+        assertThatThrownBy(() -> equipmentService.update(1L, updateEquipmentRequest))
                 .isExactlyInstanceOf(EquipmentNotFoundException.class);
     }
 }

--- a/src/test/java/com/girigiri/kwrental/item/controller/AdminItemControllerTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/controller/AdminItemControllerTest.java
@@ -2,7 +2,10 @@ package com.girigiri.kwrental.item.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.girigiri.kwrental.item.dto.request.ItemPropertyNumberRequest;
+import com.girigiri.kwrental.item.dto.request.UpdateItemRequest;
+import com.girigiri.kwrental.item.dto.request.UpdateItemsRequest;
 import com.girigiri.kwrental.item.service.ItemServiceImpl;
+import jakarta.persistence.PersistenceException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +14,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -39,6 +44,38 @@ class AdminItemControllerTest {
         mockMvc.perform(patch(PREFIX + "/1/propertyNumber")
                         .content(body)
                         .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("기자재의 품목들 수정 요청 시 자산번호가 비어있을 때 예외 처리")
+    void saveOrUpdate_emptyPropertyNumber() throws Exception {
+        // given
+        UpdateItemsRequest updateItemsRequest = new UpdateItemsRequest(List.of(new UpdateItemRequest(1L, "")));
+        String body = objectMapper.writeValueAsString(updateItemsRequest);
+
+        // when, then
+        mockMvc.perform(patch(PREFIX + "?equipmentId=1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("기자재의 품목들 수정 요청 시 자산번호가 중복되도록 수정할 경우 예외 처리")
+    void saveOrUpdate_duplicatePropertyNumber() throws Exception {
+        // given
+        UpdateItemsRequest updateItemsRequest = new UpdateItemsRequest(
+                List.of(new UpdateItemRequest(1L, "1234567")));
+        String body = objectMapper.writeValueAsString(updateItemsRequest);
+        given(itemServiceImpl.updateRentalAvailable(any(), any())).willThrow(PersistenceException.class);
+
+        // when, then
+        mockMvc.perform(patch(PREFIX + "?equipmentId=1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }

--- a/src/test/java/com/girigiri/kwrental/item/domain/EquipmentItemsTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/domain/EquipmentItemsTest.java
@@ -1,0 +1,76 @@
+package com.girigiri.kwrental.item.domain;
+
+import com.girigiri.kwrental.item.exception.EquipmentItemsException;
+import com.girigiri.kwrental.testsupport.fixture.ItemFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EquipmentItemsTest {
+
+    @Test
+    @DisplayName("중복된 ID를 가진 품목으로 생성할 경우 예외")
+    void from_duplicateId() {
+        // given
+        Item item1 = ItemFixture.builder().id(1L).propertyNumber("11111111").build();
+        Item item2 = ItemFixture.builder().id(1L).propertyNumber("22222222").build();
+
+        // when, then
+        assertThatThrownBy(() -> EquipmentItems.from(List.of(item1, item2)))
+                .isExactlyInstanceOf(EquipmentItemsException.class);
+    }
+
+    @Test
+    @DisplayName("ID가 null인 품목으로 생성할 경우 예외")
+    void from_nullId() {
+        // given
+        Item item = ItemFixture.builder().id(null).propertyNumber("22222222").build();
+
+        // when, then
+        assertThatThrownBy(() -> EquipmentItems.from(List.of(item)))
+                .isExactlyInstanceOf(EquipmentItemsException.class);
+    }
+
+    @Test
+    @DisplayName("중복된 자산번호를 가진 품목으로 생성할 경우 예외")
+    void from_duplicatePropertyNumber() {
+        // given
+        Item item1 = ItemFixture.builder().id(1L).propertyNumber("11111111").build();
+        Item item2 = ItemFixture.builder().id(2L).propertyNumber("11111111").build();
+
+        // when, then
+        assertThatThrownBy(() -> EquipmentItems.from(List.of(item1, item2)))
+                .isExactlyInstanceOf(EquipmentItemsException.class);
+    }
+
+    @Test
+    @DisplayName("자산 번호가 null인 품목으로 생성할 경우 예외")
+    void from_nullPropertyNumber() {
+        // given
+        Item item = ItemFixture.builder().id(null).propertyNumber("22222222").build();
+
+        // when, then
+        assertThatThrownBy(() -> EquipmentItems.from(List.of(item)))
+                .isExactlyInstanceOf(EquipmentItemsException.class);
+    }
+
+    @Test
+    @DisplayName("특정 기자재 ID를 가진 품목의 자산 번호를 수정한다.")
+    void updatePropertyNumberById() {
+        // given
+        Item item1 = ItemFixture.builder().id(1L).propertyNumber("11111111").build();
+        Item item2 = ItemFixture.builder().id(2L).propertyNumber("22222222").build();
+
+        EquipmentItems equipmentItems = EquipmentItems.from(List.of(item1, item2));
+
+        // when
+        equipmentItems.updatePropertyNumberById(1L, "33333333");
+
+        // then
+        assertThat(item1.getPropertyNumber()).isEqualTo("33333333");
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/item/domain/ItemTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/domain/ItemTest.java
@@ -1,0 +1,58 @@
+package com.girigiri.kwrental.item.domain;
+
+import com.girigiri.kwrental.item.exception.ItemException;
+import com.girigiri.kwrental.testsupport.fixture.ItemFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ItemTest {
+
+    @Test
+    @DisplayName("자산번호를 다르게 수정")
+    void updatePropertyNumber() {
+        // given
+        Item item = ItemFixture.builder().propertyNumber("1234567").build();
+
+        // when
+        item.updatePropertyNumber("7654321");
+
+        // then
+        assertThat(item.getPropertyNumber()).isEqualTo("7654321");
+    }
+
+    @Test
+    @DisplayName("자산번호를 null로 수정 시 예외")
+    void updatePropertyNumber_Null() {
+        // given
+        Item item = ItemFixture.builder().propertyNumber("1234567").build();
+
+        // when, then
+        assertThatThrownBy(() -> item.updatePropertyNumber(null))
+                .isInstanceOf(ItemException.class);
+    }
+
+    @Test
+    @DisplayName("자산번호를 빈 값으로 수정 시 예외")
+    void updatePropertyNumber_empty() {
+        // given
+        Item item = ItemFixture.builder().propertyNumber("1234567").build();
+
+        // when, then
+        assertThatThrownBy(() -> item.updatePropertyNumber(""))
+                .isInstanceOf(ItemException.class);
+    }
+
+    @Test
+    @DisplayName("자산번호를 공백으로 수정 시 예외")
+    void updatePropertyNumber_blank() {
+        // given
+        Item item = ItemFixture.builder().propertyNumber("1234567").build();
+
+        // when, then
+        assertThatThrownBy(() -> item.updatePropertyNumber("     "))
+                .isInstanceOf(ItemException.class);
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/item/repository/ItemQueryDslRepositoryCustomImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/repository/ItemQueryDslRepositoryCustomImplTest.java
@@ -4,6 +4,7 @@ import com.girigiri.kwrental.config.JpaConfig;
 import com.girigiri.kwrental.item.domain.Item;
 import com.girigiri.kwrental.testsupport.fixture.ItemFixture;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,5 +69,21 @@ class ItemQueryDslRepositoryCustomImplTest {
         // when, then
         assertThatThrownBy(() -> itemRepository.updatePropertyNumber(item.getId(), propertyNumber))
                 .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("중복된 자산 번호로 더티체킹 될 경우 예외")
+    void updatePropertyNumber_dirtyCheck() {
+        // given
+        String propertyNumber = "87654321";
+        Item item = ItemFixture.builder().propertyNumber("12345678").build();
+        Item item2 = ItemFixture.builder().propertyNumber(propertyNumber).build();
+        itemRepository.save(item);
+        itemRepository.save(item2);
+
+        // when
+        item.updatePropertyNumber(propertyNumber);
+        assertThatThrownBy(() -> entityManager.flush())
+                .isExactlyInstanceOf(PersistenceException.class);
     }
 }

--- a/src/test/java/com/girigiri/kwrental/item/service/ItemServiceImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/service/ItemServiceImplTest.java
@@ -125,7 +125,7 @@ class ItemServiceImplTest {
         long equipmentId = 1L;
 
         // when
-        ItemsResponse itemsResponse = itemService.updateOrSave(equipmentId, updateItemsRequest);
+        ItemsResponse itemsResponse = itemService.saveOrUpdate(equipmentId, updateItemsRequest);
 
         // then
         assertThat(itemsResponse.items()).hasSize(2);


### PR DESCRIPTION
# 구현한 내용
- 기자재 정보 수정 API
- 특정 기자재의 품목들을 추가하거나 수정하는 API
## 주의할 점
편의 상 두 로직을 다른 요청으로 분리했다. 이렇게하면 기자재가 품목에 의존하지 않을 수 있다.  또한 트랜잭션도 분리되서 한 커넥션이 오래동안 리소스를 점유하지 않도록 할 수 있다. 하지만 다른 API가 롤백됐을 때 다른 API가 롤백되지 않는다. 현 서비스는 굳이 같이 롤백되어야 될 필요성을 느끼지 못해서 일단 분리된 트랜잭션으로 진행하기로 했다.