### PR TITLE
담은 기자재들 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/inventory.adoc
+++ b/src/docs/asciidoc/inventory.adoc
@@ -3,3 +3,7 @@
 === 담은 기자재 등록
 
 operation::addInventory[snippets='http-request,http-response']
+
+=== 담은 기자재들 조회
+
+operation::getInventories[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/equipment/service/EquipmentService.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/service/EquipmentService.java
@@ -105,11 +105,12 @@ public class EquipmentService {
     }
 
     @Transactional(readOnly = true)
-    public void validateRentalDays(final Long id, final Integer rentalDays) {
+    public Equipment validateRentalDays(final Long id, final Integer rentalDays) {
         final Equipment equipment = equipmentRepository.findById(id)
                 .orElseThrow(EquipmentNotFoundException::new);
         if (!equipment.canRentFor(rentalDays)) {
             throw new EquipmentException("최대 대여일 보다 더 길게 대여할 수 없습니다.");
         }
+        return equipment;
     }
 }

--- a/src/main/java/com/girigiri/kwrental/inventory/controller/InventoryController.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/controller/InventoryController.java
@@ -1,13 +1,11 @@
 package com.girigiri.kwrental.inventory.controller;
 
 import com.girigiri.kwrental.inventory.dto.request.AddInventoryRequest;
+import com.girigiri.kwrental.inventory.dto.response.InventoriesResponse;
 import com.girigiri.kwrental.inventory.service.InventoryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -26,5 +24,10 @@ public class InventoryController {
         final Long id = inventoryService.save(addInventoryRequest);
         return ResponseEntity.created(URI.create("/api/inventories/" + id))
                 .build();
+    }
+
+    @GetMapping
+    public InventoriesResponse find() {
+        return inventoryService.getInventories();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/Inventory.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/Inventory.java
@@ -1,5 +1,6 @@
 package com.girigiri.kwrental.inventory.domain;
 
+import com.girigiri.kwrental.equipment.domain.Equipment;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,17 +20,16 @@ public class Inventory {
 
     @Column(nullable = false)
     private Integer amount;
-
-    @Column(nullable = false)
-    private Long equipmentId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Equipment equipment;
 
     protected Inventory() {
     }
 
-    public Inventory(final Long id, final RentalPeriod rentalPeriod, final Integer amount, final Long equipmentId) {
+    public Inventory(final Long id, final RentalPeriod rentalPeriod, final Integer amount, final Equipment equipment) {
         this.id = id;
         this.rentalPeriod = rentalPeriod;
         this.amount = amount;
-        this.equipmentId = equipmentId;
+        this.equipment = equipment;
     }
 }

--- a/src/main/java/com/girigiri/kwrental/inventory/dto/response/InventoriesResponse.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/dto/response/InventoriesResponse.java
@@ -1,0 +1,27 @@
+package com.girigiri.kwrental.inventory.dto.response;
+
+import com.girigiri.kwrental.inventory.domain.Inventory;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+
+public class InventoriesResponse {
+
+    private List<InventoryResponse> inventories;
+
+    private InventoriesResponse() {
+    }
+
+    private InventoriesResponse(final List<InventoryResponse> inventories) {
+        this.inventories = inventories;
+    }
+
+    public static InventoriesResponse from(final List<Inventory> inventories) {
+        final List<InventoryResponse> inventoryResponses = inventories.stream()
+                .map(InventoryResponse::from)
+                .toList();
+        return new InventoriesResponse(inventoryResponses);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/inventory/dto/response/InventoryResponse.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/dto/response/InventoryResponse.java
@@ -1,0 +1,52 @@
+package com.girigiri.kwrental.inventory.dto.response;
+
+import com.girigiri.kwrental.equipment.domain.Equipment;
+import com.girigiri.kwrental.inventory.domain.Inventory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class InventoryResponse {
+
+    private Long id;
+    private String rentalPlace;
+    private String modelName;
+    private String category;
+    private String maker;
+    private String imgUrl;
+    private LocalDate rentalStartDate;
+    private LocalDate rentalEndDate;
+    private Integer amount;
+
+    private InventoryResponse(final Long id, final String rentalPlace, final String modelName,
+                              final String category, final String maker, final String imgUrl,
+                              final LocalDate rentalStartDate, final LocalDate rentalEndDate, final Integer amount) {
+        this.id = id;
+        this.rentalPlace = rentalPlace;
+        this.modelName = modelName;
+        this.category = category;
+        this.maker = maker;
+        this.imgUrl = imgUrl;
+        this.rentalStartDate = rentalStartDate;
+        this.rentalEndDate = rentalEndDate;
+        this.amount = amount;
+    }
+
+    public static InventoryResponse from(final Inventory inventory) {
+        final Equipment equipment = inventory.getEquipment();
+        return InventoryResponse.builder()
+                .id(inventory.getId())
+                .rentalPlace(equipment.getRentalPlace())
+                .modelName(equipment.getModelName())
+                .category(equipment.getCategory().name())
+                .maker(equipment.getMaker())
+                .imgUrl(equipment.getImgUrl())
+                .rentalStartDate(inventory.getRentalPeriod().getRentalStartDate())
+                .rentalEndDate(inventory.getRentalPeriod().getRentalEndDate())
+                .amount(inventory.getAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/repository/InventoryRepository.java
@@ -3,7 +3,7 @@ package com.girigiri.kwrental.inventory.repository;
 import com.girigiri.kwrental.inventory.domain.Inventory;
 import org.springframework.data.repository.Repository;
 
-public interface InventoryRepository extends Repository<Inventory, Long> {
+public interface InventoryRepository extends Repository<Inventory, Long>, InventoryRepositoryCustom {
 
     Inventory save(Inventory inventory);
 }

--- a/src/main/java/com/girigiri/kwrental/inventory/repository/InventoryRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/repository/InventoryRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.girigiri.kwrental.inventory.repository;
+
+import com.girigiri.kwrental.inventory.domain.Inventory;
+
+import java.util.List;
+
+public interface InventoryRepositoryCustom {
+    List<Inventory> findAllWithEquipment();
+}

--- a/src/main/java/com/girigiri/kwrental/inventory/repository/InventoryRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/repository/InventoryRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package com.girigiri.kwrental.inventory.repository;
+
+import com.girigiri.kwrental.inventory.domain.Inventory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.util.List;
+
+import static com.girigiri.kwrental.equipment.domain.QEquipment.equipment;
+import static com.girigiri.kwrental.inventory.domain.QInventory.inventory;
+
+public class InventoryRepositoryCustomImpl implements InventoryRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public InventoryRepositoryCustomImpl(final JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    // TODO: 2023/04/06 회원으로 필터링 해야 한다.
+    @Override
+    public List<Inventory> findAllWithEquipment() {
+        return jpaQueryFactory.selectFrom(inventory)
+                .leftJoin(equipment).fetchJoin()
+                .fetch();
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/inventory/service/InventoryService.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/service/InventoryService.java
@@ -1,11 +1,15 @@
 package com.girigiri.kwrental.inventory.service;
 
+import com.girigiri.kwrental.equipment.domain.Equipment;
 import com.girigiri.kwrental.equipment.service.EquipmentService;
 import com.girigiri.kwrental.inventory.domain.Inventory;
 import com.girigiri.kwrental.inventory.domain.RentalPeriod;
 import com.girigiri.kwrental.inventory.dto.request.AddInventoryRequest;
+import com.girigiri.kwrental.inventory.dto.response.InventoriesResponse;
 import com.girigiri.kwrental.inventory.repository.InventoryRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class InventoryService {
@@ -24,19 +28,24 @@ public class InventoryService {
     public Long save(final AddInventoryRequest addInventoryRequest) {
         final RentalPeriod rentalPeriod = new RentalPeriod(addInventoryRequest.getRentalStartDate(), addInventoryRequest.getRentalEndDate());
         final Long equipmentId = addInventoryRequest.getEquipmentId();
-        equipmentService.validateRentalDays(equipmentId, rentalPeriod.getRentalDays());
+        final Equipment equipment = equipmentService.validateRentalDays(equipmentId, rentalPeriod.getRentalDays());
         amountValidator.validateAmount(equipmentId, addInventoryRequest.getAmount(), rentalPeriod);
-        final Inventory mapedInventory = mapToInventory(addInventoryRequest);
-        final Inventory inventory = inventoryRepository.save(mapedInventory);
+        final Inventory inventory = inventoryRepository.save(mapToInventory(equipment, addInventoryRequest));
         return inventory.getId();
     }
 
-    private Inventory mapToInventory(final AddInventoryRequest addInventoryRequest) {
+    private Inventory mapToInventory(final Equipment equipment, final AddInventoryRequest addInventoryRequest) {
         final RentalPeriod rentalPeriod = new RentalPeriod(addInventoryRequest.getRentalStartDate(), addInventoryRequest.getRentalEndDate());
         return Inventory.builder()
-                .equipmentId(addInventoryRequest.getEquipmentId())
+                .equipment(equipment)
                 .rentalPeriod(rentalPeriod)
                 .amount(addInventoryRequest.getAmount())
                 .build();
+    }
+
+    // TODO: 2023/04/06 회원이 담은 기자재를 조회해야 된다.
+    public InventoriesResponse getInventories() {
+        final List<Inventory> inventories = inventoryRepository.findAllWithEquipment();
+        return InventoriesResponse.from(inventories);
     }
 }

--- a/src/test/java/com/girigiri/kwrental/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/inventory/service/InventoryServiceTest.java
@@ -1,8 +1,10 @@
 package com.girigiri.kwrental.inventory.service;
 
+import com.girigiri.kwrental.equipment.domain.Equipment;
 import com.girigiri.kwrental.equipment.service.EquipmentService;
 import com.girigiri.kwrental.inventory.dto.request.AddInventoryRequest;
 import com.girigiri.kwrental.inventory.repository.InventoryRepository;
+import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
 import com.girigiri.kwrental.testsupport.fixture.InventoryFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,8 +40,9 @@ class InventoryServiceTest {
     void saveInventory() {
         // given
         doNothing().when(amountValidator).validateAmount(any(), any(), any());
-        doNothing().when(equipmentService).validateRentalDays(any(), any());
-        given(inventoryRepository.save(any())).willReturn(InventoryFixture.builder().id(1L).build());
+        final Equipment equipment = EquipmentFixture.builder().id(1L).build();
+        given(equipmentService.validateRentalDays(any(), any())).willReturn(equipment);
+        given(inventoryRepository.save(any())).willReturn(InventoryFixture.builder(equipment).id(1L).build());
         final AddInventoryRequest addInventoryRequest = AddInventoryRequest.builder()
                 .equipmentId(1L)
                 .amount(1)

--- a/src/test/java/com/girigiri/kwrental/testsupport/fixture/InventoryFixture.java
+++ b/src/test/java/com/girigiri/kwrental/testsupport/fixture/InventoryFixture.java
@@ -1,5 +1,6 @@
 package com.girigiri.kwrental.testsupport.fixture;
 
+import com.girigiri.kwrental.equipment.domain.Equipment;
 import com.girigiri.kwrental.inventory.domain.Inventory;
 import com.girigiri.kwrental.inventory.domain.RentalPeriod;
 
@@ -9,17 +10,17 @@ import static com.girigiri.kwrental.inventory.domain.Inventory.InventoryBuilder;
 
 public class InventoryFixture {
 
-    public static Inventory create() {
-        return builder().build();
+    public static Inventory create(final Equipment equipment) {
+        return builder(equipment).build();
     }
 
-    public static InventoryBuilder builder() {
+    public static InventoryBuilder builder(final Equipment equipment) {
         final LocalDate rentalStartDate = LocalDate.now().plusDays(1);
         final LocalDate rentalEndDate = rentalStartDate.plusDays(1);
 
         return Inventory.builder()
                 .amount(1)
                 .rentalPeriod(new RentalPeriod(rentalStartDate, rentalEndDate))
-                .equipmentId(1L);
+                .equipment(equipment);
     }
 }


### PR DESCRIPTION
# 구현한 내용
- 담은 기자재는 조회될 때 항상 기자재와 함께 조회되어서 연관관계 매핑해줘서 추가.
- 조회시 N+1 문제를 방지하기 위해 fetch join 적용
- 담은 기자재 조회 시 회원의 담은 기자재들을 보여줘야 하는데 아직 회원 기능이 없어서 일단 모든 담은 기자재 조회되도록 구현. 추후에 보완해야 함.