### PR TITLE
특정 날짜가 대여 수령일인 대여 예약 조회 API

### DIFF
--- a/src/docs/asciidoc/reservation.adoc
+++ b/src/docs/asciidoc/reservation.adoc
@@ -7,3 +7,7 @@ operation::addReservations[snippets='http-request,http-response']
 === 관리자 특정 기자재 품목 대여 현황 API
 
 operation::admin_getReservationByEquipment[snippets='http-request,http-response']
+
+=== 관리자 특정 날짜에 수령 예정인 대여 예약 조회 API
+
+operation::admin_getReservationsByStartDate[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/controller/AdminReservationController.java
@@ -1,11 +1,13 @@
 package com.girigiri.kwrental.reservation.controller;
 
 import com.girigiri.kwrental.reservation.dto.response.ReservationsByEquipmentPerYearMonthResponse;
+import com.girigiri.kwrental.reservation.dto.response.ReservationsByStartDateResponse;
 import com.girigiri.kwrental.reservation.service.ReservationService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 
 @RestController
@@ -21,5 +23,10 @@ public class AdminReservationController {
     @GetMapping
     public ReservationsByEquipmentPerYearMonthResponse getReservationsByEquipmentPerYearMonth(final Long equipmentId, final YearMonth yearMonth) {
         return reservationService.getReservationsByEquipmentsPerYearMonth(equipmentId, yearMonth);
+    }
+
+    @GetMapping(params = "startDate")
+    public ReservationsByStartDateResponse getReservationsByStartDate(final LocalDate startDate) {
+        return reservationService.getReservationsByStartDate(startDate);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
@@ -1,5 +1,7 @@
 package com.girigiri.kwrental.reservation.domain;
 
+import com.girigiri.kwrental.inventory.domain.RentalPeriod;
+import com.girigiri.kwrental.reservation.exception.ReservationException;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,11 +39,22 @@ public class Reservation {
     @Builder
     private Reservation(final Long id, final List<ReservationSpec> reservationSpecs, final String name, final String email, final String phoneNumber, final String purpose) {
         this.id = id;
+        validateReservationSpec(reservationSpecs);
         this.reservationSpecs = reservationSpecs;
         reservationSpecs.forEach(it -> it.setReservation(this));
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;
         this.purpose = purpose;
+    }
+
+    private void validateReservationSpec(final List<ReservationSpec> reservationSpecs) {
+        if (reservationSpecs == null || reservationSpecs.isEmpty()) {
+            throw new ReservationException("대여 상세 내용이 없습니다.");
+        }
+        final RentalPeriod period = reservationSpecs.get(0).getPeriod();
+        reservationSpecs.forEach(spec -> {
+            if (!spec.hasPeriod(period)) throw new ReservationException("대여 상세 내용들의 대여 기간이 통일되지 않았습니다.");
+        });
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/ReservationSpec.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/ReservationSpec.java
@@ -52,4 +52,8 @@ public class ReservationSpec {
     public LocalDate getStartDate() {
         return period.getRentalStartDate();
     }
+
+    public boolean hasPeriod(final RentalPeriod period) {
+        return this.period.equals(period);
+    }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/dto/response/ReservationResponse.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/dto/response/ReservationResponse.java
@@ -1,0 +1,30 @@
+package com.girigiri.kwrental.reservation.dto.response;
+
+import com.girigiri.kwrental.reservation.domain.Reservation;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ReservationResponse {
+
+    private String name;
+    private String memberNumber;
+    private List<ReservationSpecResponse> reservationSpecs;
+
+    private ReservationResponse() {
+    }
+
+    private ReservationResponse(final String name, final String memberNumber, final List<ReservationSpecResponse> reservationSpecs) {
+        this.name = name;
+        this.memberNumber = memberNumber;
+        this.reservationSpecs = reservationSpecs;
+    }
+
+    public static ReservationResponse from(final Reservation reservation) {
+        final List<ReservationSpecResponse> reservationSpecResponses = reservation.getReservationSpecs().stream()
+                .map(ReservationSpecResponse::from)
+                .toList();
+        return new ReservationResponse(reservation.getName(), "11111111", reservationSpecResponses);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/dto/response/ReservationResponse.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/dto/response/ReservationResponse.java
@@ -25,6 +25,7 @@ public class ReservationResponse {
         final List<ReservationSpecResponse> reservationSpecResponses = reservation.getReservationSpecs().stream()
                 .map(ReservationSpecResponse::from)
                 .toList();
+        // TODO: 2023/04/26 학번을 제대로 적용해줘야 함
         return new ReservationResponse(reservation.getName(), "11111111", reservationSpecResponses);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/dto/response/ReservationSpecResponse.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/dto/response/ReservationSpecResponse.java
@@ -1,0 +1,36 @@
+package com.girigiri.kwrental.reservation.dto.response;
+
+import com.girigiri.kwrental.equipment.domain.Equipment;
+import com.girigiri.kwrental.reservation.domain.ReservationSpec;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReservationSpecResponse {
+
+    private String imgUrl;
+    private String category;
+    private String modelName;
+    private Integer amount;
+
+    private ReservationSpecResponse() {
+    }
+
+    @Builder
+    private ReservationSpecResponse(final String imgUrl, final String category, final String modelName, final Integer amount) {
+        this.imgUrl = imgUrl;
+        this.category = category;
+        this.modelName = modelName;
+        this.amount = amount;
+    }
+
+    public static ReservationSpecResponse from(final ReservationSpec reservationSpec) {
+        final Equipment equipment = reservationSpec.getEquipment();
+        return ReservationSpecResponse.builder()
+                .imgUrl(equipment.getImgUrl())
+                .category(equipment.getCategory().name())
+                .modelName(equipment.getModelName())
+                .amount(reservationSpec.getAmount().getAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/dto/response/ReservationsByStartDateResponse.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/dto/response/ReservationsByStartDateResponse.java
@@ -1,0 +1,26 @@
+package com.girigiri.kwrental.reservation.dto.response;
+
+import com.girigiri.kwrental.reservation.domain.Reservation;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ReservationsByStartDateResponse {
+
+    private List<ReservationResponse> reservations;
+
+    private ReservationsByStartDateResponse() {
+    }
+
+    private ReservationsByStartDateResponse(final List<ReservationResponse> reservations) {
+        this.reservations = reservations;
+    }
+
+    public static ReservationsByStartDateResponse from(List<Reservation> reservations) {
+        final List<ReservationResponse> reservationResponses = reservations.stream()
+                .map(ReservationResponse::from)
+                .toList();
+        return new ReservationsByStartDateResponse(reservationResponses);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/exception/ReservationException.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/exception/ReservationException.java
@@ -1,0 +1,9 @@
+package com.girigiri.kwrental.reservation.exception;
+
+import com.girigiri.kwrental.common.exception.DomainException;
+
+public class ReservationException extends DomainException {
+    public ReservationException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepository.java
@@ -3,7 +3,7 @@ package com.girigiri.kwrental.reservation.repository;
 import com.girigiri.kwrental.reservation.domain.Reservation;
 import org.springframework.data.repository.Repository;
 
-public interface ReservationRepository extends Repository<Reservation, Long> {
+public interface ReservationRepository extends Repository<Reservation, Long>, ReservationRepositoryCustom {
 
     Reservation save(Reservation reservation);
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.girigiri.kwrental.reservation.repository;
+
+import com.girigiri.kwrental.reservation.domain.Reservation;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ReservationRepositoryCustom {
+
+    List<Reservation> findReservationsWithSpecsByStartDate(LocalDate startDate);
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.girigiri.kwrental.reservation.repository;
+
+import com.girigiri.kwrental.reservation.domain.Reservation;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.girigiri.kwrental.reservation.domain.QReservation.reservation;
+import static com.girigiri.kwrental.reservation.domain.QReservationSpec.reservationSpec;
+
+public class ReservationRepositoryCustomImpl implements ReservationRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public ReservationRepositoryCustomImpl(final JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public List<Reservation> findReservationsWithSpecsByStartDate(final LocalDate startDate) {
+        return jpaQueryFactory.selectFrom(reservation)
+                .join(reservation.reservationSpecs, reservationSpec).fetchJoin()
+                .join(reservationSpec.equipment).fetchJoin()
+                .where(reservationSpec.period.rentalStartDate.eq(startDate))
+                .fetch();
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepository.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepository.java
@@ -3,7 +3,7 @@ package com.girigiri.kwrental.reservation.repository;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import org.springframework.data.repository.Repository;
 
-public interface RentalSpecRepository extends Repository<ReservationSpec, Long>, RentalSpecRepositoryCustom {
+public interface ReservationSpecRepository extends Repository<ReservationSpec, Long>, ReservationSpecRepositoryCustom {
 
     ReservationSpec save(ReservationSpec reservationSpec);
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustom.java
@@ -7,7 +7,7 @@ import com.girigiri.kwrental.reservation.dto.ReservedAmount;
 import java.time.LocalDate;
 import java.util.List;
 
-public interface RentalSpecRepositoryCustom {
+public interface ReservationSpecRepositoryCustom {
     List<ReservationSpec> findOverlappedByPeriod(Long equipmentId, RentalPeriod rentalPeriod);
 
     List<ReservedAmount> findRentalAmountsByEquipmentIds(List<Long> equipmentIds, LocalDate date);

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustomImpl.java
@@ -13,11 +13,11 @@ import java.util.stream.Stream;
 import static com.girigiri.kwrental.equipment.domain.QEquipment.equipment;
 import static com.girigiri.kwrental.reservation.domain.QReservationSpec.reservationSpec;
 
-public class RentalSpecRepositoryCustomImpl implements RentalSpecRepositoryCustom {
+public class ReservationSpecRepositoryCustomImpl implements ReservationSpecRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    public RentalSpecRepositoryCustomImpl(final JPAQueryFactory queryFactory) {
+    public ReservationSpecRepositoryCustomImpl(final JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
     }
 

--- a/src/main/java/com/girigiri/kwrental/reservation/service/ReservationService.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/service/ReservationService.java
@@ -7,9 +7,10 @@ import com.girigiri.kwrental.reservation.domain.ReservationCalendar;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.dto.request.AddReservationRequest;
 import com.girigiri.kwrental.reservation.dto.response.ReservationsByEquipmentPerYearMonthResponse;
-import com.girigiri.kwrental.reservation.repository.RentalSpecRepositoryCustom;
+import com.girigiri.kwrental.reservation.dto.response.ReservationsByStartDateResponse;
 import com.girigiri.kwrental.reservation.repository.ReservationRepository;
-import org.springframework.beans.factory.annotation.Qualifier;
+import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
+import com.girigiri.kwrental.reservation.repository.ReservationSpecRepositoryCustom;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,11 +24,11 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final InventoryService inventoryService;
     private final RemainingQuantityServiceImpl remainingQuantityService;
-    private final RentalSpecRepositoryCustom rentalSpecRepository;
+    private final ReservationSpecRepositoryCustom rentalSpecRepository;
 
     public ReservationService(final ReservationRepository reservationRepository, final InventoryService inventoryService,
                               final RemainingQuantityServiceImpl remainingQuantityService,
-                              @Qualifier("rentalSpecRepository") final RentalSpecRepositoryCustom rentalSpecRepository) {
+                              final ReservationSpecRepository rentalSpecRepository) {
         this.reservationRepository = reservationRepository;
         this.inventoryService = inventoryService;
         this.remainingQuantityService = remainingQuantityService;
@@ -75,5 +76,11 @@ public class ReservationService {
         final ReservationCalendar calendar = ReservationCalendar.from(startOfMonth, endOfMonth);
         calendar.addAll(reservationSpecs);
         return ReservationsByEquipmentPerYearMonthResponse.from(calendar);
+    }
+
+    @Transactional(readOnly = true)
+    public ReservationsByStartDateResponse getReservationsByStartDate(final LocalDate startDate) {
+        final List<Reservation> reservations = reservationRepository.findReservationsWithSpecsByStartDate(startDate);
+        return ReservationsByStartDateResponse.from(reservations);
     }
 }

--- a/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
@@ -9,7 +9,7 @@ import com.girigiri.kwrental.equipment.dto.response.*;
 import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
 import com.girigiri.kwrental.inventory.domain.RentalAmount;
 import com.girigiri.kwrental.inventory.domain.RentalPeriod;
-import com.girigiri.kwrental.reservation.repository.RentalSpecRepository;
+import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
 import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
 import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
 import io.restassured.RestAssured;
@@ -41,7 +41,7 @@ class EquipmentAcceptanceTest extends AcceptanceTest {
     private EquipmentRepository equipmentRepository;
 
     @Autowired
-    private RentalSpecRepository rentalSpecRepository;
+    private ReservationSpecRepository reservationSpecRepository;
 
     @Test
     @DisplayName("기자재 세부 내역 조회 API")
@@ -174,9 +174,9 @@ class EquipmentAcceptanceTest extends AcceptanceTest {
         final Equipment equipment2 = EquipmentFixture.builder().modelName("equipment2").totalQuantity(10).build();
         equipmentRepository.save(equipment2);
         LocalDate date = LocalDate.of(2023, 1, 1);
-        rentalSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(5)).period(new RentalPeriod(date, date.plusDays(1))).build());
-        rentalSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(2)).period(new RentalPeriod(date, date.plusDays(1))).build());
-        rentalSpecRepository.save(ReservationSpecFixture.builder(equipment2).amount(new RentalAmount(5)).period(new RentalPeriod(date, date.plusDays(1))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(5)).period(new RentalPeriod(date, date.plusDays(1))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(2)).period(new RentalPeriod(date, date.plusDays(1))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment2).amount(new RentalAmount(5)).period(new RentalPeriod(date, date.plusDays(1))).build());
 
         // when
         final EquipmentsWithRentalQuantityPageResponse response = RestAssured.given(this.requestSpec)

--- a/src/test/java/com/girigiri/kwrental/acceptance/ReservationAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/ReservationAcceptanceTest.java
@@ -78,7 +78,8 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         final Item item = itemRepository.save(ItemFixture.builder().equipmentId(equipment.getId()).build());
         final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment).period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
         final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment).period(new RentalPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2))).build();
-        final Reservation reservation = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1, reservationSpec2)));
+        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1)));
+        final Reservation reservation2 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec2)));
 
         // when
         final ReservationsByEquipmentPerYearMonthResponse response = RestAssured.given(requestSpec)
@@ -90,7 +91,7 @@ class ReservationAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
                 () -> assertThat(response.getReservations().get(LocalDate.now().getDayOfMonth()))
-                        .usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(reservation.getName())
+                        .usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(reservation1.getName())
         );
     }
 

--- a/src/test/java/com/girigiri/kwrental/acceptance/ReservationAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/ReservationAcceptanceTest.java
@@ -10,7 +10,9 @@ import com.girigiri.kwrental.item.repository.ItemRepository;
 import com.girigiri.kwrental.reservation.domain.Reservation;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.dto.request.AddReservationRequest;
+import com.girigiri.kwrental.reservation.dto.response.ReservationResponse;
 import com.girigiri.kwrental.reservation.dto.response.ReservationsByEquipmentPerYearMonthResponse;
+import com.girigiri.kwrental.reservation.dto.response.ReservationsByStartDateResponse;
 import com.girigiri.kwrental.reservation.repository.ReservationRepository;
 import com.girigiri.kwrental.testsupport.fixture.*;
 import io.restassured.RestAssured;
@@ -90,5 +92,34 @@ class ReservationAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.getReservations().get(LocalDate.now().getDayOfMonth()))
                         .usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(reservation.getName())
         );
+    }
+
+    @Test
+    @DisplayName("특절 날짜에 수령일인 대여 예약을 조회한다.")
+    void getReservationsByStartDate() {
+        // given
+        final Equipment equipment1 = equipmentRepository.save(EquipmentFixture.builder().modelName("test1").build());
+        final Item item1 = itemRepository.save(ItemFixture.builder().propertyNumber("11111111").equipmentId(equipment1.getId()).build());
+        final Equipment equipment2 = equipmentRepository.save(EquipmentFixture.builder().modelName("test2").build());
+        final Item item2 = itemRepository.save(ItemFixture.builder().propertyNumber("22222222").equipmentId(equipment2.getId()).build());
+
+        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment1).period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
+        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
+        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1, reservationSpec2)));
+
+        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2))).build();
+        final ReservationSpec reservationSpec4 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2))).build();
+        final Reservation reservation2 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec3, reservationSpec4)));
+
+        // when
+        final ReservationsByStartDateResponse response = RestAssured.given(requestSpec)
+                .filter(document("admin_getReservationsByStartDate"))
+                .when().log().all().get("/api/admin/reservations?startDate={startDate}", LocalDate.now().toString())
+                .then().log().all().statusCode(HttpStatus.OK.value())
+                .extract().as(ReservationsByStartDateResponse.class);
+
+        // then
+        assertThat(response.getReservations()).usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(ReservationResponse.from(reservation1));
     }
 }

--- a/src/test/java/com/girigiri/kwrental/reservation/domain/ReservationCalendarTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/domain/ReservationCalendarTest.java
@@ -28,7 +28,9 @@ class ReservationCalendarTest {
                 .period(new RentalPeriod(now.atEndOfMonth(), now.atEndOfMonth().plusDays(1))).build();
         final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(equipment)
                 .period(new RentalPeriod(now.atEndOfMonth().plusDays(1), now.atEndOfMonth().plusDays(2))).build();
-        final Reservation reservation = ReservationFixture.create(List.of(reservationSpec1, reservationSpec2, reservationSpec3));
+        final Reservation reservation1 = ReservationFixture.create(List.of(reservationSpec1));
+        final Reservation reservation2 = ReservationFixture.create(List.of(reservationSpec2));
+        final Reservation reservation3 = ReservationFixture.create(List.of(reservationSpec3));
         final ReservationCalendar calendar = ReservationCalendar.from(now.atDay(1), now.atEndOfMonth());
 
         // when
@@ -36,8 +38,8 @@ class ReservationCalendarTest {
 
         // then
         assertAll(
-                () -> assertThat(calendar.getCalendar().get(1)).containsOnly(reservation.getName()),
-                () -> assertThat(calendar.getCalendar().get(now.atEndOfMonth().getDayOfMonth())).containsOnly(reservation.getName())
+                () -> assertThat(calendar.getCalendar().get(1)).containsOnly(reservation1.getName()),
+                () -> assertThat(calendar.getCalendar().get(now.atEndOfMonth().getDayOfMonth())).containsOnly(reservation1.getName())
         );
     }
 }

--- a/src/test/java/com/girigiri/kwrental/reservation/domain/ReservationTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/domain/ReservationTest.java
@@ -1,0 +1,34 @@
+package com.girigiri.kwrental.reservation.domain;
+
+import com.girigiri.kwrental.inventory.domain.RentalPeriod;
+import com.girigiri.kwrental.reservation.exception.ReservationException;
+import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class ReservationTest {
+
+    @Test
+    @DisplayName("대여 기간이 다른 대여 예약 상세를 가질 수 없다.")
+    void construct_invalidPeriod() {
+        // given
+        final ReservationSpec spec1 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
+        final ReservationSpec spec2 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(2))).build();
+
+        // when
+        assertThatThrownBy(() -> Reservation
+                .builder()
+                .reservationSpecs(List.of(spec1, spec2))
+                .name("name")
+                .email("email@email.com")
+                .purpose("purpose")
+                .phoneNumber("01073015510")
+                .build()
+        ).isExactlyInstanceOf(ReservationException.class);
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustomImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustomImplTest.java
@@ -1,0 +1,55 @@
+package com.girigiri.kwrental.reservation.repository;
+
+import com.girigiri.kwrental.config.JpaConfig;
+import com.girigiri.kwrental.equipment.domain.Equipment;
+import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
+import com.girigiri.kwrental.inventory.domain.RentalPeriod;
+import com.girigiri.kwrental.reservation.domain.Reservation;
+import com.girigiri.kwrental.reservation.domain.ReservationSpec;
+import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
+import com.girigiri.kwrental.testsupport.fixture.ReservationFixture;
+import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class ReservationRepositoryCustomImplTest {
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private EquipmentRepository equipmentRepository;
+
+
+    @Test
+    @DisplayName("대여 수령일로 대여 예약을 조회")
+    void findReservationsWithSpecsByStartDate() {
+        // given
+        final Equipment equipment1 = equipmentRepository.save(EquipmentFixture.builder().modelName("test1").build());
+        final Equipment equipment2 = equipmentRepository.save(EquipmentFixture.builder().modelName("test2").build());
+
+        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment1).period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
+        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
+        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1, reservationSpec2)));
+
+        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2))).build();
+        final ReservationSpec reservationSpec4 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2))).build();
+        final Reservation reservation2 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec3, reservationSpec4)));
+
+        // when
+        final List<Reservation> expect = reservationRepository.findReservationsWithSpecsByStartDate(LocalDate.now());
+
+        // then
+        assertThat(expect).containsExactly(reservation1);
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustomImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustomImplTest.java
@@ -29,7 +29,7 @@ class ReservationSpecRepositoryCustomImplTest {
 
     public static final LocalDate NOW = LocalDate.now();
     @Autowired
-    private RentalSpecRepository rentalSpecRepository;
+    private ReservationSpecRepository reservationSpecRepository;
 
     @Autowired
     private EquipmentRepository equipmentRepository;
@@ -48,11 +48,11 @@ class ReservationSpecRepositoryCustomImplTest {
 
 
         List.of(notOverlappedLeft, overlappedLeft, overlappedMid, overlappedRight, notOverlappedRight, overlappedBoth)
-                .forEach(it -> rentalSpecRepository.save(ReservationSpecFixture.builder(equipment).period(it).build()));
+                .forEach(it -> reservationSpecRepository.save(ReservationSpecFixture.builder(equipment).period(it).build()));
 
         // when
         final RentalPeriod period = new RentalPeriod(NOW.plusDays(1), NOW.plusDays(4));
-        final List<ReservationSpec> expect = rentalSpecRepository.findOverlappedByPeriod(equipment.getId(), period);
+        final List<ReservationSpec> expect = reservationSpecRepository.findOverlappedByPeriod(equipment.getId(), period);
 
         // then
         assertThat(expect).usingRecursiveFieldByFieldElementComparator()
@@ -72,12 +72,12 @@ class ReservationSpecRepositoryCustomImplTest {
         final ReservationSpec reservationSpec1 = rentalSpec1Builder.amount(new RentalAmount(2)).period(new RentalPeriod(NOW, NOW.plusDays(2))).build();
         final ReservationSpec reservationSpec2 = rentalSpec1Builder.amount(new RentalAmount(1)).period(new RentalPeriod(NOW, NOW.plusDays(1))).build();
         final ReservationSpec reservationSpec3 = rentalSpec1Builder.amount(new RentalAmount(1)).period(new RentalPeriod(NOW.plusDays(1), NOW.plusDays(2))).build();
-        rentalSpecRepository.save(reservationSpec1);
-        rentalSpecRepository.save(reservationSpec2);
-        rentalSpecRepository.save(reservationSpec3);
+        reservationSpecRepository.save(reservationSpec1);
+        reservationSpecRepository.save(reservationSpec2);
+        reservationSpecRepository.save(reservationSpec3);
 
         // when
-        final List<ReservedAmount> expect = rentalSpecRepository.findRentalAmountsByEquipmentIds(List.of(equipment1.getId(), equipment2.getId(), equipment3.getId()), NOW);
+        final List<ReservedAmount> expect = reservationSpecRepository.findRentalAmountsByEquipmentIds(List.of(equipment1.getId(), equipment2.getId(), equipment3.getId()), NOW);
 
         // then
         final ReservedAmount reservedAmount1 = new ReservedAmount(equipment1.getId(), 4, 3);
@@ -97,12 +97,12 @@ class ReservationSpecRepositoryCustomImplTest {
         // given
         final Equipment equipment = equipmentRepository.save(EquipmentFixture.create());
         final YearMonth now = YearMonth.now();
-        final ReservationSpec reservationSpec1 = rentalSpecRepository.save(ReservationSpecFixture.builder(equipment).period(new RentalPeriod(now.atDay(1), now.atEndOfMonth())).build());
-        final ReservationSpec reservationSpec2 = rentalSpecRepository.save(ReservationSpecFixture.builder(equipment).period(new RentalPeriod(now.atEndOfMonth(), now.atEndOfMonth().plusDays(1))).build());
-        final ReservationSpec reservationSpec3 = rentalSpecRepository.save(ReservationSpecFixture.builder(equipment).period(new RentalPeriod(now.atEndOfMonth().plusDays(1), now.atEndOfMonth().plusDays(2))).build());
+        final ReservationSpec reservationSpec1 = reservationSpecRepository.save(ReservationSpecFixture.builder(equipment).period(new RentalPeriod(now.atDay(1), now.atEndOfMonth())).build());
+        final ReservationSpec reservationSpec2 = reservationSpecRepository.save(ReservationSpecFixture.builder(equipment).period(new RentalPeriod(now.atEndOfMonth(), now.atEndOfMonth().plusDays(1))).build());
+        final ReservationSpec reservationSpec3 = reservationSpecRepository.save(ReservationSpecFixture.builder(equipment).period(new RentalPeriod(now.atEndOfMonth().plusDays(1), now.atEndOfMonth().plusDays(2))).build());
 
         // when
-        final List<ReservationSpec> expect = rentalSpecRepository.findByStartDateBetween(equipment.getId(), now.atDay(1), now.atEndOfMonth());
+        final List<ReservationSpec> expect = reservationSpecRepository.findByStartDateBetween(equipment.getId(), now.atDay(1), now.atEndOfMonth());
 
         // then
         assertThat(expect).containsExactlyInAnyOrder(reservationSpec1, reservationSpec2);

--- a/src/test/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImplTest.java
@@ -6,7 +6,7 @@ import com.girigiri.kwrental.inventory.domain.RentalAmount;
 import com.girigiri.kwrental.inventory.domain.RentalPeriod;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.exception.NotEnoughAmountException;
-import com.girigiri.kwrental.reservation.repository.RentalSpecRepository;
+import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
 import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
 import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +29,7 @@ import static org.mockito.BDDMockito.given;
 class RemainingQuantityServiceImplTest {
 
     @Mock
-    private RentalSpecRepository rentalSpecRepository;
+    private ReservationSpecRepository reservationSpecRepository;
 
     @Mock
     private EquipmentRepository equipmentRepository;
@@ -48,7 +48,7 @@ class RemainingQuantityServiceImplTest {
                 .period(new RentalPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2))).build();
 
         given(equipmentRepository.findById(any())).willReturn(Optional.of(equipment));
-        given(rentalSpecRepository.findOverlappedByPeriod(any(), any())).willReturn(List.of(reservationSpec1, reservationSpec2));
+        given(reservationSpecRepository.findOverlappedByPeriod(any(), any())).willReturn(List.of(reservationSpec1, reservationSpec2));
 
         // when, then
         assertThatCode(() -> remainingQuantityService.validateAmount(1L, 1, new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))))
@@ -66,7 +66,7 @@ class RemainingQuantityServiceImplTest {
                 .period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
 
         given(equipmentRepository.findById(any())).willReturn(Optional.of(equipment));
-        given(rentalSpecRepository.findOverlappedByPeriod(any(), any())).willReturn(List.of(reservationSpec1, reservationSpec2));
+        given(reservationSpecRepository.findOverlappedByPeriod(any(), any())).willReturn(List.of(reservationSpec1, reservationSpec2));
 
         // when, then
         assertThatThrownBy(() -> remainingQuantityService.validateAmount(1L, 1, new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))))

--- a/src/test/java/com/girigiri/kwrental/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/service/ReservationServiceTest.java
@@ -7,8 +7,8 @@ import com.girigiri.kwrental.reservation.domain.Reservation;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.dto.request.AddReservationRequest;
 import com.girigiri.kwrental.reservation.dto.response.ReservationsByEquipmentPerYearMonthResponse;
-import com.girigiri.kwrental.reservation.repository.RentalSpecRepository;
 import com.girigiri.kwrental.reservation.repository.ReservationRepository;
+import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
 import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
 import com.girigiri.kwrental.testsupport.fixture.InventoryFixture;
 import com.girigiri.kwrental.testsupport.fixture.ReservationFixture;
@@ -39,7 +39,7 @@ class ReservationServiceTest {
     private ReservationRepository reservationRepository;
 
     @Mock
-    private RentalSpecRepository rentalSpecRepository;
+    private ReservationSpecRepository reservationSpecRepository;
 
     @InjectMocks
     private ReservationService reservationService;
@@ -82,7 +82,7 @@ class ReservationServiceTest {
         final Equipment equipment = EquipmentFixture.create();
         final ReservationSpec reservationSpec = ReservationSpecFixture.builder(equipment).build();
         final Reservation reservation = ReservationFixture.create(List.of(reservationSpec));
-        given(rentalSpecRepository.findByStartDateBetween(any(), any(), any()))
+        given(reservationSpecRepository.findByStartDateBetween(any(), any(), any()))
                 .willReturn(List.of(reservationSpec));
 
         // when

--- a/src/test/java/com/girigiri/kwrental/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/service/ReservationServiceTest.java
@@ -6,7 +6,9 @@ import com.girigiri.kwrental.inventory.service.InventoryService;
 import com.girigiri.kwrental.reservation.domain.Reservation;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.dto.request.AddReservationRequest;
+import com.girigiri.kwrental.reservation.dto.response.ReservationResponse;
 import com.girigiri.kwrental.reservation.dto.response.ReservationsByEquipmentPerYearMonthResponse;
+import com.girigiri.kwrental.reservation.dto.response.ReservationsByStartDateResponse;
 import com.girigiri.kwrental.reservation.repository.ReservationRepository;
 import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
 import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
@@ -20,6 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -90,5 +93,23 @@ class ReservationServiceTest {
 
         // then
         assertThat(expect.getReservations().get(reservationSpec.getStartDate().getDayOfMonth())).containsExactlyInAnyOrder(reservation.getName());
+    }
+
+    @Test
+    @DisplayName("특정 날짜에 수령하는 대여 예약을 조회한다.")
+    void getReservationsByStartDate() {
+        // given
+        final Equipment equipment = EquipmentFixture.create();
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(equipment).build();
+        final Reservation reservation = ReservationFixture.create(List.of(reservationSpec));
+        given(reservationRepository.findReservationsWithSpecsByStartDate(any()))
+                .willReturn(List.of(reservation));
+
+        // when
+        final ReservationsByStartDateResponse reservationsByStartDate = reservationService.getReservationsByStartDate(LocalDate.now());
+
+        // then
+        assertThat(reservationsByStartDate.getReservations()).usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(ReservationResponse.from(reservation));
     }
 }


### PR DESCRIPTION

<img width="378" alt="스크린샷 2023-04-26 오전 3 50 42" src="https://user-images.githubusercontent.com/87690744/234374472-4bd1bdb1-8870-416a-bebd-b3cc9dcb55a1.png">

등록된 대여 예약 중 대여 예약 시작일이 입력한 날짜인 것만 조회되도록 한다. 이때 학점은 예약한 회원 정보가 있어야 가능해서 일단 가짜 데이터로 대응하였다.