### PR TITLE
대여가능한 품목 조회 API

### DIFF
--- a/src/docs/asciidoc/item.adoc
+++ b/src/docs/asciidoc/item.adoc
@@ -25,3 +25,7 @@ operation::admin_updateItemsByEquipment[snippets='http-request,http-response']
 === 관리자 기자재 품목 삭제 API
 
 operation::admin_deleteItem[snippets='http-request,http-response']
+
+=== 현 시점 수령 가능한 품목 조회 API
+
+operation::admin_getAcceptableItems[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/equipment/service/SaveItemService.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/service/SaveItemService.java
@@ -1,9 +1,10 @@
 package com.girigiri.kwrental.equipment.service;
 
 import com.girigiri.kwrental.equipment.dto.request.AddItemRequest;
+
 import java.util.List;
 
-public interface ItemService {
+public interface SaveItemService {
 
     void saveItems(final Long equipmentId, List<AddItemRequest> itemRequests);
 }

--- a/src/main/java/com/girigiri/kwrental/item/controller/AdminItemController.java
+++ b/src/main/java/com/girigiri/kwrental/item/controller/AdminItemController.java
@@ -3,6 +3,7 @@ package com.girigiri.kwrental.item.controller;
 import com.girigiri.kwrental.item.dto.request.ItemPropertyNumberRequest;
 import com.girigiri.kwrental.item.dto.request.ItemRentalAvailableRequest;
 import com.girigiri.kwrental.item.dto.request.UpdateItemsRequest;
+import com.girigiri.kwrental.item.dto.response.ItemsResponse;
 import com.girigiri.kwrental.item.service.ItemService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -44,5 +45,10 @@ public class AdminItemController {
     public ResponseEntity<?> saveOrUpdate(final Long equipmentId, @RequestBody @Validated UpdateItemsRequest updateItemsRequest) {
         itemService.saveOrUpdate(equipmentId, updateItemsRequest);
         return ResponseEntity.noContent().location(URI.create("/api/items?equipmentId=" + equipmentId)).build();
+    }
+
+    @GetMapping("/rentalAvailability")
+    public ItemsResponse getRentalAvailable(final Long equipmentId) {
+        return itemService.getRentalAvailableItems(equipmentId);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/item/controller/AdminItemController.java
+++ b/src/main/java/com/girigiri/kwrental/item/controller/AdminItemController.java
@@ -3,7 +3,7 @@ package com.girigiri.kwrental.item.controller;
 import com.girigiri.kwrental.item.dto.request.ItemPropertyNumberRequest;
 import com.girigiri.kwrental.item.dto.request.ItemRentalAvailableRequest;
 import com.girigiri.kwrental.item.dto.request.UpdateItemsRequest;
-import com.girigiri.kwrental.item.service.ItemServiceImpl;
+import com.girigiri.kwrental.item.service.ItemService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -14,9 +14,9 @@ import java.net.URI;
 @RequestMapping("/api/admin/items")
 public class AdminItemController {
 
-    private final ItemServiceImpl itemService;
+    private final ItemService itemService;
 
-    public AdminItemController(final ItemServiceImpl itemService) {
+    public AdminItemController(final ItemService itemService) {
         this.itemService = itemService;
     }
 

--- a/src/main/java/com/girigiri/kwrental/item/controller/ItemController.java
+++ b/src/main/java/com/girigiri/kwrental/item/controller/ItemController.java
@@ -2,7 +2,7 @@ package com.girigiri.kwrental.item.controller;
 
 import com.girigiri.kwrental.item.dto.response.ItemResponse;
 import com.girigiri.kwrental.item.dto.response.ItemsResponse;
-import com.girigiri.kwrental.item.service.ItemServiceImpl;
+import com.girigiri.kwrental.item.service.ItemService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/items")
 public class ItemController {
 
-    private final ItemServiceImpl itemService;
+    private final ItemService itemService;
 
-    public ItemController(final ItemServiceImpl itemService) {
+    public ItemController(final ItemService itemService) {
         this.itemService = itemService;
     }
 

--- a/src/main/java/com/girigiri/kwrental/item/domain/Item.java
+++ b/src/main/java/com/girigiri/kwrental/item/domain/Item.java
@@ -18,7 +18,7 @@ public class Item {
     private String propertyNumber;
 
     @Builder.Default
-    private boolean rentalAvailable = true;
+    private boolean available = true;
 
     @Column(nullable = false)
     private Long equipmentId;
@@ -26,10 +26,10 @@ public class Item {
     protected Item() {
     }
 
-    public Item(final Long id, final String propertyNumber, final boolean rentalAvailable, final Long equipmentId) {
+    public Item(final Long id, final String propertyNumber, final boolean available, final Long equipmentId) {
         this.id = id;
         this.propertyNumber = propertyNumber;
-        this.rentalAvailable = rentalAvailable;
+        this.available = available;
         this.equipmentId = equipmentId;
     }
 

--- a/src/main/java/com/girigiri/kwrental/item/domain/ItemsPerEquipments.java
+++ b/src/main/java/com/girigiri/kwrental/item/domain/ItemsPerEquipments.java
@@ -30,7 +30,7 @@ public class ItemsPerEquipments {
         for (String propertyNumber : propertyNumbers) {
             final Item item = itemsPerPropertyNumber.get(propertyNumber);
             if (item == null) throw new ItemNotFoundException();
-            if (!item.isRentalAvailable()) throw new ItemNotAvailableException();
+            if (!item.isAvailable()) throw new ItemNotAvailableException();
         }
     }
 

--- a/src/main/java/com/girigiri/kwrental/item/dto/response/ItemResponse.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/response/ItemResponse.java
@@ -9,7 +9,7 @@ public record ItemResponse(
         Long equipmentId
 ) {
     public static ItemResponse from(final Item item) {
-        return new ItemResponse(item.getId(), item.getPropertyNumber(), item.isRentalAvailable(),
+        return new ItemResponse(item.getId(), item.getPropertyNumber(), item.isAvailable(),
                 item.getEquipmentId());
     }
 }

--- a/src/main/java/com/girigiri/kwrental/item/repository/ItemJdbcRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/item/repository/ItemJdbcRepositoryCustomImpl.java
@@ -15,7 +15,7 @@ public class ItemJdbcRepositoryCustomImpl implements ItemJdbcRepositoryCustom {
 
     @Override
     public int saveAll(final List<Item> items) {
-        final String query = "INSERT INTO item (property_number, rental_available, equipment_id) values (?, ?, ?)";
+        final String query = "INSERT INTO item (property_number, available, equipment_id) values (?, ?, ?)";
         final int[][] affectedRows = jdbcTemplate.batchUpdate(query, items, items.size(), (ps, arg) -> {
             ps.setString(1, arg.getPropertyNumber());
             ps.setBoolean(2, arg.isAvailable());

--- a/src/main/java/com/girigiri/kwrental/item/repository/ItemJdbcRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/item/repository/ItemJdbcRepositoryCustomImpl.java
@@ -1,8 +1,9 @@
 package com.girigiri.kwrental.item.repository;
 
 import com.girigiri.kwrental.item.domain.Item;
-import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
 
 public class ItemJdbcRepositoryCustomImpl implements ItemJdbcRepositoryCustom {
 
@@ -17,7 +18,7 @@ public class ItemJdbcRepositoryCustomImpl implements ItemJdbcRepositoryCustom {
         final String query = "INSERT INTO item (property_number, rental_available, equipment_id) values (?, ?, ?)";
         final int[][] affectedRows = jdbcTemplate.batchUpdate(query, items, items.size(), (ps, arg) -> {
             ps.setString(1, arg.getPropertyNumber());
-            ps.setBoolean(2, arg.isRentalAvailable());
+            ps.setBoolean(2, arg.isAvailable());
             ps.setLong(3, arg.getEquipmentId());
         });
         return sum(affectedRows);

--- a/src/main/java/com/girigiri/kwrental/item/repository/ItemQueryDslRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/item/repository/ItemQueryDslRepositoryCustomImpl.java
@@ -18,10 +18,10 @@ public class ItemQueryDslRepositoryCustomImpl implements ItemQueryDslRepositoryC
     }
 
     @Override
-    public int updateRentalAvailable(final Long id, final boolean rentalAvailable) {
+    public int updateRentalAvailable(final Long id, final boolean available) {
         return (int) jpaQueryFactory.update(item)
                 .where(item.id.eq(id))
-                .set(item.rentalAvailable, rentalAvailable)
+                .set(item.available, available)
                 .execute();
     }
 
@@ -37,7 +37,7 @@ public class ItemQueryDslRepositoryCustomImpl implements ItemQueryDslRepositoryC
     public int countAvailable(final Long equipmentId) {
         return Objects.requireNonNull(jpaQueryFactory.select(item.count())
                 .from(item)
-                .where(item.equipmentId.eq(equipmentId).and(item.rentalAvailable.isTrue()))
+                .where(item.equipmentId.eq(equipmentId).and(item.available.isTrue()))
                 .fetchOne()).intValue();
     }
 

--- a/src/main/java/com/girigiri/kwrental/item/service/ItemService.java
+++ b/src/main/java/com/girigiri/kwrental/item/service/ItemService.java
@@ -1,9 +1,6 @@
 package com.girigiri.kwrental.item.service;
 
-import com.girigiri.kwrental.equipment.dto.request.AddItemRequest;
-import com.girigiri.kwrental.equipment.exception.EquipmentNotFoundException;
-import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
-import com.girigiri.kwrental.equipment.service.ItemService;
+import com.girigiri.kwrental.equipment.service.EquipmentService;
 import com.girigiri.kwrental.item.domain.EquipmentItems;
 import com.girigiri.kwrental.item.domain.Item;
 import com.girigiri.kwrental.item.domain.ItemsPerEquipments;
@@ -26,37 +23,21 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
-public class ItemServiceImpl implements ItemService {
+public class ItemService {
 
     private final ItemRepository itemRepository;
-    private final EquipmentRepository equipmentRepository;
+    private final EquipmentService equipmentService;
+    private final RentedItemService rentedItemService;
 
-    public ItemServiceImpl(final ItemRepository itemRepository, final EquipmentRepository equipmentRepository) {
+    public ItemService(final ItemRepository itemRepository, final EquipmentService equipmentService, final RentedItemService rentedItemService) {
         this.itemRepository = itemRepository;
-        this.equipmentRepository = equipmentRepository;
-    }
-
-    @Override
-    @Transactional
-    public void saveItems(final Long equipmentId, final List<AddItemRequest> itemRequests) {
-        final List<Item> items = itemRequests.stream()
-                .map(it -> mapToItem(equipmentId, it))
-                .toList();
-        itemRepository.saveAll(items);
-    }
-
-    private Item mapToItem(final Long equipmentId, final AddItemRequest addItemRequest) {
-        return Item.builder()
-                .equipmentId(equipmentId)
-                .propertyNumber(addItemRequest.propertyNumber())
-                .rentalAvailable(true)
-                .build();
+        this.equipmentService = equipmentService;
+        this.rentedItemService = rentedItemService;
     }
 
     @Transactional(readOnly = true)
     public ItemsResponse getItems(final Long equipmentId) {
-        equipmentRepository.findById(equipmentId)
-                .orElseThrow(EquipmentNotFoundException::new);
+        equipmentService.validateExistsById(equipmentId);
         final List<Item> items = itemRepository.findByEquipmentId(equipmentId);
         return ItemsResponse.of(items);
     }

--- a/src/main/java/com/girigiri/kwrental/item/service/RentedItemService.java
+++ b/src/main/java/com/girigiri/kwrental/item/service/RentedItemService.java
@@ -1,0 +1,9 @@
+package com.girigiri.kwrental.item.service;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public interface RentedItemService {
+
+    Set<String> getRentedPropertyNumbers(Long equipmentId, LocalDateTime date);
+}

--- a/src/main/java/com/girigiri/kwrental/item/service/SaveItemServiceImpl.java
+++ b/src/main/java/com/girigiri/kwrental/item/service/SaveItemServiceImpl.java
@@ -32,7 +32,7 @@ public class SaveItemServiceImpl implements SaveItemService {
         return Item.builder()
                 .equipmentId(equipmentId)
                 .propertyNumber(addItemRequest.propertyNumber())
-                .rentalAvailable(true)
+                .available(true)
                 .build();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/item/service/SaveItemServiceImpl.java
+++ b/src/main/java/com/girigiri/kwrental/item/service/SaveItemServiceImpl.java
@@ -1,0 +1,38 @@
+package com.girigiri.kwrental.item.service;
+
+import com.girigiri.kwrental.equipment.dto.request.AddItemRequest;
+import com.girigiri.kwrental.equipment.service.SaveItemService;
+import com.girigiri.kwrental.item.domain.Item;
+import com.girigiri.kwrental.item.repository.ItemRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class SaveItemServiceImpl implements SaveItemService {
+
+    private final ItemRepository itemRepository;
+
+    public SaveItemServiceImpl(final ItemRepository itemRepository) {
+        this.itemRepository = itemRepository;
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void saveItems(final Long equipmentId, final List<AddItemRequest> itemRequests) {
+        final List<Item> items = itemRequests.stream()
+                .map(it -> mapToItem(equipmentId, it))
+                .toList();
+        itemRepository.saveAll(items);
+    }
+
+    private Item mapToItem(final Long equipmentId, final AddItemRequest addItemRequest) {
+        return Item.builder()
+                .equipmentId(equipmentId)
+                .propertyNumber(addItemRequest.propertyNumber())
+                .rentalAvailable(true)
+                .build();
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.girigiri.kwrental.rental.repository;
 
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -9,4 +10,6 @@ public interface RentalSpecRepositoryCustom {
     List<RentalSpec> findByPropertyNumbers(Set<String> propertyNumbers);
 
     List<RentalSpec> findByReservationSpecIds(Set<Long> reservationSpecIds);
+
+    Set<RentalSpec> findRentedRentalSpecs(Long equipmentId, LocalDateTime date);
 }

--- a/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustomImpl.java
@@ -3,10 +3,12 @@ package com.girigiri.kwrental.rental.repository;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
 import static com.girigiri.kwrental.rental.domain.QRentalSpec.rentalSpec;
+import static com.girigiri.kwrental.reservation.domain.QReservationSpec.reservationSpec;
 
 public class RentalSpecRepositoryCustomImpl implements RentalSpecRepositoryCustom {
 
@@ -28,5 +30,16 @@ public class RentalSpecRepositoryCustomImpl implements RentalSpecRepositoryCusto
         return jpaQueryFactory.selectFrom(rentalSpec)
                 .where(rentalSpec.reservationSpecId.in(reservationSpecIds))
                 .fetch();
+    }
+
+    @Override
+    public Set<RentalSpec> findRentedRentalSpecs(final Long equipmentId, final LocalDateTime dateTime) {
+        return Set.copyOf(
+                jpaQueryFactory.selectFrom(rentalSpec)
+                        .leftJoin(reservationSpec).on(rentalSpec.reservationSpecId.eq(reservationSpec.id))
+                        .where(reservationSpec.equipment.id.eq(equipmentId)
+                                .and(rentalSpec.acceptDateTime.loe(dateTime))
+                                .and(rentalSpec.returnDateTime.isNull()))
+                        .fetch());
     }
 }

--- a/src/main/java/com/girigiri/kwrental/rental/service/RentalService.java
+++ b/src/main/java/com/girigiri/kwrental/rental/service/RentalService.java
@@ -1,6 +1,6 @@
 package com.girigiri.kwrental.rental.service;
 
-import com.girigiri.kwrental.item.service.ItemServiceImpl;
+import com.girigiri.kwrental.item.service.ItemService;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.girigiri.kwrental.rental.dto.request.CreateRentalRequest;
 import com.girigiri.kwrental.rental.dto.request.RentalSpecsRequest;
@@ -25,11 +25,11 @@ import static java.util.stream.Collectors.toMap;
 @Service
 public class RentalService {
 
-    private final ItemServiceImpl itemService;
+    private final ItemService itemService;
     private final ReservationService reservationService;
     private final RentalSpecRepository rentalSpecRepository;
 
-    public RentalService(final ItemServiceImpl itemService, final ReservationService reservationService, final RentalSpecRepository rentalSpecRepository) {
+    public RentalService(final ItemService itemService, final ReservationService reservationService, final RentalSpecRepository rentalSpecRepository) {
         this.itemService = itemService;
         this.reservationService = reservationService;
         this.rentalSpecRepository = rentalSpecRepository;

--- a/src/main/java/com/girigiri/kwrental/rental/service/RentedItemServiceImpl.java
+++ b/src/main/java/com/girigiri/kwrental/rental/service/RentedItemServiceImpl.java
@@ -1,0 +1,31 @@
+package com.girigiri.kwrental.rental.service;
+
+import com.girigiri.kwrental.item.service.RentedItemService;
+import com.girigiri.kwrental.rental.domain.RentalSpec;
+import com.girigiri.kwrental.rental.repository.RentalSpecRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class RentedItemServiceImpl implements RentedItemService {
+
+    private RentalSpecRepository rentalSpecRepository;
+
+    public RentedItemServiceImpl(final RentalSpecRepository rentalSpecRepository) {
+        this.rentalSpecRepository = rentalSpecRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true, propagation = Propagation.MANDATORY)
+    public Set<String> getRentedPropertyNumbers(final Long equipmentId, final LocalDateTime dateTime) {
+        return rentalSpecRepository.findRentedRentalSpecs(equipmentId, dateTime)
+                .stream()
+                .map(RentalSpec::getPropertyNumber)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/equipment/service/EquipmentServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/equipment/service/EquipmentServiceTest.java
@@ -39,7 +39,7 @@ class EquipmentServiceTest {
     private EquipmentRepository equipmentRepository;
 
     @Mock
-    private ItemService itemService;
+    private SaveItemService saveItemService;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -143,7 +143,7 @@ class EquipmentServiceTest {
         // then
         assertThat(id).isOne();
         verify(equipmentRepository).save(any());
-        verify(itemService).saveItems(any(), any());
+        verify(saveItemService).saveItems(any(), any());
     }
 
     @Test

--- a/src/test/java/com/girigiri/kwrental/item/controller/AdminItemControllerTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/controller/AdminItemControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.girigiri.kwrental.item.dto.request.ItemPropertyNumberRequest;
 import com.girigiri.kwrental.item.dto.request.UpdateItemRequest;
 import com.girigiri.kwrental.item.dto.request.UpdateItemsRequest;
-import com.girigiri.kwrental.item.service.ItemServiceImpl;
+import com.girigiri.kwrental.item.service.ItemService;
 import jakarta.persistence.PersistenceException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,13 +31,13 @@ class AdminItemControllerTest {
     @Autowired
     private MockMvc mockMvc;
     @MockBean
-    private ItemServiceImpl itemServiceImpl;
+    private ItemService itemService;
 
     @Test
     @DisplayName("중복된 품목 자산번호로 수정할 때 예외 처리")
     void updatePropertyNumber_duplicatedKey() throws Exception {
         // given
-        given(itemServiceImpl.updatePropertyNumber(any(), any())).willThrow(DataIntegrityViolationException.class);
+        given(itemService.updatePropertyNumber(any(), any())).willThrow(DataIntegrityViolationException.class);
         String body = objectMapper.writeValueAsString(new ItemPropertyNumberRequest("12345678"));
 
         // when, then
@@ -70,7 +70,7 @@ class AdminItemControllerTest {
         UpdateItemsRequest updateItemsRequest = new UpdateItemsRequest(
                 List.of(new UpdateItemRequest(1L, "1234567")));
         String body = objectMapper.writeValueAsString(updateItemsRequest);
-        given(itemServiceImpl.updateRentalAvailable(any(), any())).willThrow(PersistenceException.class);
+        given(itemService.updateRentalAvailable(any(), any())).willThrow(PersistenceException.class);
 
         // when, then
         mockMvc.perform(patch(PREFIX + "?equipmentId=1")

--- a/src/test/java/com/girigiri/kwrental/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/controller/ItemControllerTest.java
@@ -2,7 +2,7 @@ package com.girigiri.kwrental.item.controller;
 
 import com.girigiri.kwrental.equipment.exception.EquipmentNotFoundException;
 import com.girigiri.kwrental.item.exception.ItemNotFoundException;
-import com.girigiri.kwrental.item.service.ItemServiceImpl;
+import com.girigiri.kwrental.item.service.ItemService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,13 +22,13 @@ class ItemControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    ItemServiceImpl itemServiceImpl;
+    ItemService itemService;
 
     @Test
     @DisplayName("존재하지 않는 기자재 품목 목록 조회 예외 처리")
     void getItems_notFound() throws Exception {
         long notExistsId = 1L;
-        given(itemServiceImpl.getItems(notExistsId)).willThrow(EquipmentNotFoundException.class);
+        given(itemService.getItems(notExistsId)).willThrow(EquipmentNotFoundException.class);
 
         // when, then
         mockMvc.perform(get(PREFIX + "?equipmentId=" + notExistsId))
@@ -40,7 +40,7 @@ class ItemControllerTest {
     void getItem_notFound() throws Exception {
         // given
         long notExistsId = 1L;
-        given(itemServiceImpl.getItem(notExistsId)).willThrow(ItemNotFoundException.class);
+        given(itemService.getItem(notExistsId)).willThrow(ItemNotFoundException.class);
 
         // when, then
         mockMvc.perform(get(PREFIX + "/" + notExistsId))

--- a/src/test/java/com/girigiri/kwrental/item/domain/ItemsPerEquipmentsTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/domain/ItemsPerEquipmentsTest.java
@@ -41,7 +41,7 @@ class ItemsPerEquipmentsTest {
     @DisplayName("품목이 대여 불가능한 상황일 경우 예외 발생")
     void validatePropertyNumbersAvailable_notAvailableItem() {
         // given
-        final Item item = ItemFixture.builder().equipmentId(1L).rentalAvailable(false).build();
+        final Item item = ItemFixture.builder().equipmentId(1L).available(false).build();
         final ItemsPerEquipments items = ItemsPerEquipments.from(List.of(item));
 
         // when, then

--- a/src/test/java/com/girigiri/kwrental/item/repository/ItemQueryDslRepositoryCustomImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/repository/ItemQueryDslRepositoryCustomImplTest.java
@@ -38,7 +38,7 @@ class ItemQueryDslRepositoryCustomImplTest {
         entityManager.clear();
 
         // then
-        assertThat(itemRepository.findById(item.getId()).get().isRentalAvailable()).isFalse();
+        assertThat(itemRepository.findById(item.getId()).get().isAvailable()).isFalse();
     }
 
     @Test
@@ -92,8 +92,8 @@ class ItemQueryDslRepositoryCustomImplTest {
     @DisplayName("대여 가능 갯수를 구한다")
     void countAvailable() {
         // given
-        Item item1 = ItemFixture.builder().propertyNumber("12345678").rentalAvailable(true).build();
-        Item item2 = ItemFixture.builder().propertyNumber("87654321").rentalAvailable(false).build();
+        Item item1 = ItemFixture.builder().propertyNumber("12345678").available(true).build();
+        Item item2 = ItemFixture.builder().propertyNumber("87654321").available(false).build();
         itemRepository.save(item1);
         itemRepository.save(item2);
 

--- a/src/test/java/com/girigiri/kwrental/item/service/ItemServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/service/ItemServiceTest.java
@@ -1,8 +1,6 @@
 package com.girigiri.kwrental.item.service;
 
-import com.girigiri.kwrental.equipment.dto.request.AddItemRequest;
-import com.girigiri.kwrental.equipment.exception.EquipmentNotFoundException;
-import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
+import com.girigiri.kwrental.equipment.service.EquipmentService;
 import com.girigiri.kwrental.item.domain.Item;
 import com.girigiri.kwrental.item.dto.request.ItemPropertyNumberRequest;
 import com.girigiri.kwrental.item.dto.request.ItemRentalAvailableRequest;
@@ -30,44 +28,28 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class ItemServiceImplTest {
+class ItemServiceTest {
 
     @Mock
     ItemRepository itemRepository;
 
     @Mock
-    EquipmentRepository equipmentRepository;
+    EquipmentService equipmentService;
 
     @InjectMocks
-    ItemServiceImpl itemService;
+    ItemService itemService;
 
     @Test
-    @DisplayName("품목 Bulk Update")
-    void saveItems() {
+    @DisplayName("품목 조회")
+    void getItem() {
         // given
-        given(itemRepository.saveAll(any()))
-                .willReturn(1);
-        final AddItemRequest addItemRequest = new AddItemRequest("12345678");
-
-        // when
-        itemService.saveItems(1L, List.of(addItemRequest));
-
-        // then
-        verify(itemRepository).saveAll(any());
-    }
-
-    @Test
-    @DisplayName("존재하지 않은 기자재의 품목 목록 조회 예외")
-    void getItems_notFound() {
-        // given
-        given(equipmentRepository.findById(any())).willReturn(Optional.empty());
+        given(itemRepository.findById(any())).willReturn(Optional.empty());
 
         // when, then
-        assertThatThrownBy(() -> itemService.getItems(1L))
-                .isExactlyInstanceOf(EquipmentNotFoundException.class);
+        assertThatThrownBy(() -> itemService.getItem(1L))
+                .isExactlyInstanceOf(ItemNotFoundException.class);
     }
 
     @Test

--- a/src/test/java/com/girigiri/kwrental/item/service/SaveItemServiceImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/item/service/SaveItemServiceImplTest.java
@@ -1,0 +1,41 @@
+package com.girigiri.kwrental.item.service;
+
+import com.girigiri.kwrental.equipment.dto.request.AddItemRequest;
+import com.girigiri.kwrental.item.repository.ItemRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SaveItemServiceImplTest {
+
+    @Mock
+    private ItemRepository itemRepository;
+
+    @InjectMocks
+    private SaveItemServiceImpl saveItemService;
+
+    @Test
+    @DisplayName("품목 Bulk Update")
+    void saveItems() {
+        // given
+        given(itemRepository.saveAll(any()))
+                .willReturn(1);
+        final AddItemRequest addItemRequest = new AddItemRequest("12345678");
+
+        // when
+        saveItemService.saveItems(1L, List.of(addItemRequest));
+
+        // then
+        verify(itemRepository).saveAll(any());
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
@@ -1,15 +1,23 @@
 package com.girigiri.kwrental.rental.repository;
 
 import com.girigiri.kwrental.config.JpaConfig;
+import com.girigiri.kwrental.equipment.domain.Equipment;
+import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
+import com.girigiri.kwrental.reservation.domain.ReservationSpec;
+import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
+import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
 import com.girigiri.kwrental.testsupport.fixture.RentalSpecFixture;
+import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -20,6 +28,10 @@ class RentalSpecRepositoryTest {
 
     @Autowired
     private RentalSpecRepository rentalSpecRepository;
+    @Autowired
+    private ReservationSpecRepository reservationSpecRepository;
+    @Autowired
+    private EquipmentRepository equipmentRepository;
 
     @Test
     @DisplayName("대여 상세를 모두 저장한다.")
@@ -38,5 +50,29 @@ class RentalSpecRepositoryTest {
                 () -> assertThat(rentalSpec1.getAcceptDateTime()).isNotNull(),
                 () -> assertThat(rentalSpec2.getAcceptDateTime()).isNotNull()
         );
+    }
+
+    @Test
+    @DisplayName("특정 기자재의 특정 날짜에 대여 중인 대여 상세를 조회한다.")
+    void findRentedRentalSpecs() {
+        // given
+        final LocalDateTime acceptTime = LocalDateTime.now();
+        final LocalDateTime returnTime = LocalDateTime.now();
+        final Equipment equipment1 = equipmentRepository.save(EquipmentFixture.builder().modelName("modelName1").build());
+        final Equipment equipment2 = equipmentRepository.save(EquipmentFixture.builder().modelName("modelName2").build());
+        final ReservationSpec reservationSpec1 = reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).build());
+        final ReservationSpec reservationSpec2 = reservationSpecRepository.save(ReservationSpecFixture.builder(equipment2).build());
+
+        final RentalSpec rentalSpec1 = RentalSpecFixture.builder().acceptDateTime(acceptTime).propertyNumber("11111111").reservationSpecId(reservationSpec1.getId()).build();
+        final RentalSpec rentalSpec2 = RentalSpecFixture.builder().acceptDateTime(acceptTime).returnDateTime(returnTime).propertyNumber("22222222").reservationSpecId(reservationSpec1.getId()).build();
+        final RentalSpec rentalSpec3 = RentalSpecFixture.builder().acceptDateTime(acceptTime).propertyNumber("33333333").reservationSpecId(reservationSpec2.getId()).build();
+
+        rentalSpecRepository.saveAll(List.of(rentalSpec1, rentalSpec2, rentalSpec3));
+
+        // when
+        final Set<RentalSpec> rentedRentalSpecs = rentalSpecRepository.findRentedRentalSpecs(equipment1.getId(), LocalDateTime.now());
+
+        // then
+        assertThat(rentedRentalSpecs).containsExactlyInAnyOrder(rentalSpec1);
     }
 }

--- a/src/test/java/com/girigiri/kwrental/rental/service/RentalServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/service/RentalServiceTest.java
@@ -1,7 +1,7 @@
 package com.girigiri.kwrental.rental.service;
 
 import com.girigiri.kwrental.equipment.domain.Equipment;
-import com.girigiri.kwrental.item.service.ItemServiceImpl;
+import com.girigiri.kwrental.item.service.ItemService;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.girigiri.kwrental.rental.dto.request.CreateRentalRequest;
 import com.girigiri.kwrental.rental.dto.request.RentalSpecsRequest;
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.doNothing;
 class RentalServiceTest {
 
     @Mock
-    private ItemServiceImpl itemService;
+    private ItemService itemService;
     @Mock
     private ReservationService reservationService;
     @Mock

--- a/src/test/java/com/girigiri/kwrental/rental/service/RentedItemServiceImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/service/RentedItemServiceImplTest.java
@@ -1,0 +1,41 @@
+package com.girigiri.kwrental.rental.service;
+
+import com.girigiri.kwrental.rental.repository.RentalSpecRepository;
+import com.girigiri.kwrental.testsupport.fixture.RentalSpecFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class RentedItemServiceImplTest {
+
+    @Mock
+    private RentalSpecRepository rentalSpecRepository;
+
+    @InjectMocks
+    private RentedItemServiceImpl rentedItemService;
+
+    @Test
+    @DisplayName("대여 중인 품목의 자산번호를 조회한다.")
+    void getRentedPropertyNumbers() {
+        // given
+        given(rentalSpecRepository.findRentedRentalSpecs(any(), any()))
+                .willReturn(Set.of(RentalSpecFixture.builder().propertyNumber("12345678").build()));
+
+        // when
+        final Set<String> rentedPropertyNumbers = rentedItemService.getRentedPropertyNumbers(1L, LocalDateTime.now());
+
+        // then
+        assertThat(rentedPropertyNumbers).containsOnly("12345678");
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/testsupport/fixture/ItemFixture.java
+++ b/src/test/java/com/girigiri/kwrental/testsupport/fixture/ItemFixture.java
@@ -12,7 +12,7 @@ public class ItemFixture {
         return Item.builder()
                 .equipmentId(EQUIPMENT_ID)
                 .propertyNumber(PROPERTY_NUMBER)
-                .rentalAvailable(true);
+                .available(true);
     }
 
     public static Item create() {


### PR DESCRIPTION
현시점에 특정 기자재의 대여 가능한 품목을 조회한다.

특정 기자재의 대여 상세 중 수령일이 현시점 이전이고 아직 반납하지 않은 대여 상세의 자산번호를 조회한다.
특정 기자재의 품목들 중 대여 중인 자산번호를 통해 대여 중인 품목을 제외하고, 운영하고 있지 않은 품목을 제외한 대여가능한 품목을 조회한다.