### PR TITLE
API 및 예외 로깅 구현

### DIFF
--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -10,3 +10,45 @@ files:
             # run app
             killall java
             java -Dfile.encoding=UTF-8 -Dspring.profiles.active=release -jar $JAR_PATH
+
+    "/opt/elasticbeanstalk/tasks/taillogs.d/infologs.conf":
+        mode: "000755"
+        owner: webapp
+        group: webapp
+        content: |
+          /var/app/current/logs/info/*.log
+
+    "/opt/elasticbeanstalk/tasks/bundlelogs.d/infologs.conf":
+        mode: "000755"
+        owner: webapp
+        group: webapp
+        content: |
+          /var/app/current/logs/info/*.log
+
+    "/opt/elasticbeanstalk/tasks/taillogs.d/warnlogs.conf":
+        mode: "000755"
+        owner: webapp
+        group: webapp
+        content: |
+          /var/app/current/logs/warn/*.log
+
+    "/opt/elasticbeanstalk/tasks/bundlelogs.d/warnlogs.conf":
+        mode: "000755"
+        owner: webapp
+        group: webapp
+        content: |
+          /var/app/current/logs/warn/*.log
+
+    "/opt/elasticbeanstalk/tasks/taillogs.d/errorlogs.conf":
+        mode: "000755"
+        owner: webapp
+        group: webapp
+        content: |
+          /var/app/current/logs/error/*.log
+
+    "/opt/elasticbeanstalk/tasks/bundlelogs.d/errorlogs.conf":
+        mode: "000755"
+        owner: webapp
+        group: webapp
+        content: |
+          /var/app/current/logs/error/*.log

--- a/src/main/java/com/girigiri/kwrental/GlobalExceptionAdvice.java
+++ b/src/main/java/com/girigiri/kwrental/GlobalExceptionAdvice.java
@@ -7,6 +7,7 @@ import com.girigiri.kwrental.common.exception.BadRequestException;
 import com.girigiri.kwrental.common.exception.NotFoundException;
 import jakarta.persistence.PersistenceException;
 import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
@@ -19,16 +20,23 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import java.util.Arrays;
+
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionAdvice {
 
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<?> handleNotFound(final NotFoundException notFoundException) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(notFoundException.getMessage());
+    public ResponseEntity<?> handleNotFound(final NotFoundException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<?> handleMethodArgumentTypeMismatch(final MethodArgumentTypeMismatchException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.badRequest()
                 .body(String.format("%s이 잘못된 타입으로 입력됐습니다. 입력값 : %s",
                         e.getParameter().getParameter().getName(), e.getValue()));
@@ -36,6 +44,8 @@ public class GlobalExceptionAdvice {
 
     @ExceptionHandler(BindException.class)
     public ResponseEntity<?> handleBindException(final BindException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
         StringBuilder builder = new StringBuilder();
         for (ObjectError error : e.getBindingResult().getAllErrors()) {
             builder.append(
@@ -47,54 +57,74 @@ public class GlobalExceptionAdvice {
     }
 
     @ExceptionHandler(DataAccessException.class)
-    public ResponseEntity<?> handleInvalidDataAccess() {
+    public ResponseEntity<?> handleInvalidDataAccess(final DataAccessException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.badRequest()
                 .body("데이터베이스에 잘못된 접근입니다.");
     }
 
     @ExceptionHandler({DataIntegrityViolationException.class, PersistenceException.class})
-    public ResponseEntity<?> handleDataIntegrityViolation() {
+    public ResponseEntity<?> handleDataIntegrityViolation(Exception e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.badRequest()
                 .body("데이터의 조건이 맞지 않습니다. 유일값이나 null 조건을 확인하세요.");
     }
 
     @ExceptionHandler(DuplicateKeyException.class)
-    public ResponseEntity<?> handleDuplicateKey() {
+    public ResponseEntity<?> handleDuplicateKey(final DuplicateKeyException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.badRequest().body("중복되서는 안되는 값이 중복된 요청입니다.");
     }
 
     @ExceptionHandler(AmazonServiceException.class)
     public ResponseEntity<?> handleAmazonServiceException(final AmazonServiceException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.internalServerError().body("AWS에 문제가 생겼습니다!!" + e.getMessage());
     }
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<?> handleBadRequest(final BadRequestException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.badRequest().body(e.getMessage());
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<?> handleConstraintViolation(final ConstraintViolationException e) {
+        log.error(e.getMessage());
+        log.error(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.badRequest().body("입력값 검증을 통과하지 못했습니다." + e.getMessage());
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<?> handleHttpMethodNotSupported() {
+    public ResponseEntity<?> handleHttpMethodNotSupported(final HttpRequestMethodNotSupportedException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.badRequest().body("해당 HTTP METHOD는 처리할 수 없습니다.");
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<?> handleUnauthorizedException(final UnauthorizedException unauthorizedException) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(unauthorizedException.getMessage());
+    public ResponseEntity<?> handleUnauthorizedException(final UnauthorizedException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
     }
 
     @ExceptionHandler(ForbiddenException.class)
-    public ResponseEntity<?> handleForbiddenException(final ForbiddenException forbiddenException) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(forbiddenException.getMessage());
+    public ResponseEntity<?> handleForbiddenException(final ForbiddenException e) {
+        log.warn(e.getMessage());
+        log.warn(Arrays.toString(e.getStackTrace()));
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleInternalServerError(Exception e) {
+        log.error(e.getMessage());
+        log.error(Arrays.toString(e.getStackTrace()));
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상하지 못한 예외가 발생했습니다.");
     }
 

--- a/src/main/java/com/girigiri/kwrental/common/ApiLogFilter.java
+++ b/src/main/java/com/girigiri/kwrental/common/ApiLogFilter.java
@@ -1,0 +1,112 @@
+package com.girigiri.kwrental.common;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class ApiLogFilter extends OncePerRequestFilter {
+
+    private static final String START_OF_PARAMS = "?";
+    private static final String PARAM_DELIMITER = "&";
+    private static final String KEY_VALUE_DELIMITER = "=";
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
+                                    final FilterChain filterChain)
+            throws ServletException, IOException {
+        final ContentCachingRequestWrapper cachingRequest = new ContentCachingRequestWrapper(request);
+        final ContentCachingResponseWrapper cachingResponse = new ContentCachingResponseWrapper(response);
+
+        final StopWatch requestTimeStopWatch = new StopWatch();
+        requestTimeStopWatch.start();
+        filterChain.doFilter(cachingRequest, cachingResponse);
+        requestTimeStopWatch.stop();
+
+        logRequestAndResponse(cachingRequest, cachingResponse, requestTimeStopWatch);
+        cachingResponse.copyBodyToResponse();
+    }
+
+    private void logRequestAndResponse(final ContentCachingRequestWrapper request,
+                                       final ContentCachingResponseWrapper response, final StopWatch requestTimeStopWatch) {
+        logConsumedTime(request, response, requestTimeStopWatch);
+        logBody(request, response);
+    }
+
+    private void logBody(final ContentCachingRequestWrapper request, final ContentCachingResponseWrapper response) {
+        final String requestBody = new String(request.getContentAsByteArray());
+        final HttpStatus httpStatus = HttpStatus.valueOf(response.getStatus());
+        if (httpStatus.isError() && !requestBody.isBlank()) {
+            log.warn("[Failed Request Body] : {}", requestBody);
+            getJsonResponseBody(response)
+                    .ifPresent(body -> log.warn("[Response Body] : {}", body));
+            log.warn("[Response Body] : {}", response);
+        }
+        if (httpStatus.is2xxSuccessful() && !requestBody.isBlank()) {
+            log.info("[Request Body] : {}", requestBody);
+            getJsonResponseBody(response)
+                    .ifPresent(body -> log.info("[Response Body] : {}", body));
+        }
+    }
+
+    private Optional<String> getJsonResponseBody(final ContentCachingResponseWrapper response) {
+        if (Objects.equals(response.getContentType(), MediaType.APPLICATION_JSON_VALUE)) {
+            return Optional.of(new String(response.getContentAsByteArray()));
+        }
+        return Optional.empty();
+    }
+
+    private void logConsumedTime(final HttpServletRequest request, final HttpServletResponse response, final StopWatch requestTimeStopWatch) {
+        final long totalTimeMillis = requestTimeStopWatch.getTotalTimeMillis();
+        final double seconds = totalTimeMillis / 1000.0;
+        final HttpStatus httpStatus = HttpStatus.valueOf(response.getStatus());
+        final String requestURI = getRequestURIWithParams(request);
+        if (seconds >= 0.5 || httpStatus.isError()) {
+            log.warn("[{}] {}:{} {} seconds", httpStatus, request.getMethod(), requestURI, seconds);
+        } else {
+            log.info("[{}] {}:{} {} seconds", httpStatus, request.getMethod(), requestURI, seconds);
+        }
+    }
+
+    private String getRequestURIWithParams(final HttpServletRequest request) {
+        final String requestURI = request.getRequestURI();
+        final Map<String, String[]> params = request.getParameterMap();
+        if (params.isEmpty()) {
+            return requestURI;
+        }
+        final String parsedParams = parseParams(params);
+        return requestURI + parsedParams;
+    }
+
+    private String parseParams(final Map<String, String[]> params) {
+        final String everyParamStrings = params.entrySet().stream()
+                .map(this::toParamString)
+                .collect(Collectors.joining(PARAM_DELIMITER));
+        return START_OF_PARAMS + everyParamStrings;
+    }
+
+    private String toParamString(final Map.Entry<String, String[]> entry) {
+        final String key = entry.getKey();
+        final StringBuilder builder = new StringBuilder();
+        return Arrays.stream(entry.getValue())
+                .map(value -> builder.append(key).append(KEY_VALUE_DELIMITER).append(value))
+                .collect(Collectors.joining(PARAM_DELIMITER));
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/config/WebConfig.java
+++ b/src/main/java/com/girigiri/kwrental/config/WebConfig.java
@@ -1,8 +1,12 @@
 package com.girigiri.kwrental.config;
 
+import com.girigiri.kwrental.common.ApiLogFilter;
 import com.girigiri.kwrental.common.CustomHandlerMethodArgumentResolver;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -33,5 +37,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.addAll(argumentResolvers);
+    }
+
+    @Bean
+    public FilterRegistrationBean<OncePerRequestFilter> requestLoggingFilter() {
+        final FilterRegistrationBean<OncePerRequestFilter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new ApiLogFilter());
+        filterRegistrationBean.addUrlPatterns("/api/*");
+        return filterRegistrationBean;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,13 +7,6 @@ spring:
                 use_sql_comments: true
     config:
         import: security/security-default.yml
-logging:
-    level:
-        org:
-            hibernate:
-                type:
-                    descriptor:
-                        sql: trace
 
 server:
     shutdown: graceful

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATH" value="./logs"/>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <appender name="INFO-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <file>${LOG_PATH}/info/logback.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/info/info-%d{yyyy-MM-dd-HH}.%i.log</fileNamePattern>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+            <cleanHistoryOnStart>${LOG_FILE_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="WARN-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <file>${LOG_PATH}/warn/logback.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+            <cleanHistoryOnStart>${LOG_FILE_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
+            <maxFileSize>1MB</maxFileSize>
+        </rollingPolicy>
+    </appender>
+
+    <!-- Spring Profiles -->
+    <springProfile name="default">
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+    <springProfile name="release">
+        <root level="INFO">
+            <appender-ref ref="INFO-FILE"/>
+            <appender-ref ref="WARN-FILE"/>
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+    <springProfile name="production">
+        <root level="INFO">
+            <appender-ref ref="INFO-FILE"/>
+            <appender-ref ref="WARN-FILE"/>
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -42,6 +42,25 @@
         </rollingPolicy>
     </appender>
 
+    <appender name="ERROR-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <file>${LOG_PATH}/error/logback.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+            <cleanHistoryOnStart>${LOG_FILE_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
+            <maxFileSize>1MB</maxFileSize>
+        </rollingPolicy>
+    </appender>
+
     <!-- Spring Profiles -->
     <springProfile name="default">
         <root level="info">
@@ -52,6 +71,7 @@
         <root level="INFO">
             <appender-ref ref="INFO-FILE"/>
             <appender-ref ref="WARN-FILE"/>
+            <appender-ref ref="ERROR-FILE"/>
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
@@ -59,6 +79,7 @@
         <root level="INFO">
             <appender-ref ref="INFO-FILE"/>
             <appender-ref ref="WARN-FILE"/>
+            <appender-ref ref="ERROR-FILE"/>
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>


### PR DESCRIPTION
스프링 부트에서 기본 제공하는 Logback을 활용하여 INFO, WARN, ERROR를 기준으로 구분해서 파일을 생성하는 방식으로 로깅을 구현했다.
이때 API 주소 및 바디 값은 필터를 활용했다. 왜냐면 바디값을 읽기 위해서는 바디값을 캐싱하는 특수한 요청 객체와 응답 객체로 바꿔서 필터를 진행해야 한다. 만약 인터셉터에서 읽으면 정작 요청을 처리하는 컨트롤러에서 바디값을 읽지 못하는 문제가 생겼다. 이는 더 찾아봐야 한다.
EB에는 로그 파일을 웹 콘솔에서 보려면 설정이 필요해서 추가했다.
https://docs.aws.amazon.com/ko_kr/elasticbeanstalk/latest/dg/using-features.logging.html#health-logs-instancelocation