### PR TITLE
아직 종결되지 않은 내 대여 예약 조회 API

### DIFF
--- a/src/docs/asciidoc/reservation.adoc
+++ b/src/docs/asciidoc/reservation.adoc
@@ -8,6 +8,17 @@ operation::addReservations[snippets='http-request,http-response']
 
 operation::admin_getReservationByEquipment[snippets='http-request,http-response']
 
-=== 아직 종결되지 않은 내 대여 조회 API
+=== 아직 종결되지 않은 내 대여 예약 조회 API
+
+==== 종결되지 않았다는 대여 신청한 모든 품목들이 아직 반납되지 않은 경우를 의미.
+
+각 대여 예약 상세의 상태에 대한 해석
+
+- `RESERVED` : 대여 신청
+- `RENTED` : 대여 중
+- `RETURNED` : 반납됨
+- `ABNORMAL_RETURNED` : 비정상 반납(파손, 분실, 연체 반납)
+- `OVERDUE_RENTED` : 연체 중
+- `CANCELED` : 대여 취소
 
 operation::getUnterminatedReservations[snippets='http-request,http-response']

--- a/src/docs/asciidoc/reservation.adoc
+++ b/src/docs/asciidoc/reservation.adoc
@@ -7,3 +7,7 @@ operation::addReservations[snippets='http-request,http-response']
 === 관리자 특정 기자재 품목 대여 현황 API
 
 operation::admin_getReservationByEquipment[snippets='http-request,http-response']
+
+=== 아직 종결되지 않은 내 대여 조회 API
+
+operation::getUnterminatedReservations[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
@@ -12,7 +12,7 @@ import java.time.temporal.ChronoUnit;
 @Embeddable
 @Getter
 @EqualsAndHashCode
-public class RentalPeriod {
+public class RentalPeriod implements Comparable<RentalPeriod> {
 
     @Column(nullable = false)
     private LocalDate rentalStartDate;
@@ -45,5 +45,20 @@ public class RentalPeriod {
 
     public boolean isLegalReturnIn(final LocalDate date) {
         return this.contains(date) || rentalEndDate.isEqual(date);
+    }
+
+    @Override
+    public int compareTo(final RentalPeriod o) {
+        if (o == null) return 1;
+        if (this.rentalStartDate.isBefore(o.rentalStartDate)) {
+            return -1;
+        }
+        if (this.rentalStartDate.isEqual(o.rentalStartDate) && this.rentalEndDate.isBefore(o.rentalEndDate)) {
+            return -1;
+        }
+        if (this.rentalStartDate.isEqual(o.rentalStartDate) && this.rentalEndDate.isEqual(o.rentalEndDate)) {
+            return 0;
+        }
+        return 1;
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/controller/ReservationController.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/controller/ReservationController.java
@@ -2,13 +2,12 @@ package com.girigiri.kwrental.reservation.controller;
 
 import com.girigiri.kwrental.auth.domain.SessionMember;
 import com.girigiri.kwrental.auth.interceptor.UserMember;
+import com.girigiri.kwrental.common.exception.BadRequestException;
 import com.girigiri.kwrental.reservation.dto.request.AddReservationRequest;
+import com.girigiri.kwrental.reservation.dto.response.UnterminatedReservationsResponse;
 import com.girigiri.kwrental.reservation.service.ReservationService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -26,5 +25,11 @@ public class ReservationController {
     public ResponseEntity<?> reserve(@UserMember final SessionMember sessionMember, @RequestBody final AddReservationRequest addReservationRequest) {
         final Long id = reservationService.reserve(sessionMember.getId(), addReservationRequest);
         return ResponseEntity.created(URI.create("/api/reservations/" + id)).build();
+    }
+
+    @GetMapping(params = "terminated")
+    public UnterminatedReservationsResponse findUnterminatedReservations(@UserMember final SessionMember sessionMember, final Boolean terminated) {
+        if (!terminated) return reservationService.getUnterminatedReservations(sessionMember.getId());
+        throw new BadRequestException("terminated가 true인 경우는 제공하지 않습니다.");
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -86,5 +87,17 @@ public class Reservation {
                                 && it != ReservationSpecStatus.RENTED
                                 && it != ReservationSpecStatus.OVERDUE_RENTED
                 );
+    }
+
+    public RentalPeriod getRentalPeriod() {
+        return new RentalPeriod(getStartDate(), getEndDate());
+    }
+
+    public LocalDate getStartDate() {
+        return this.reservationSpecs.get(0).getStartDate();
+    }
+
+    public LocalDate getEndDate() {
+        return this.reservationSpecs.get(0).getEndDate();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/ReservationSpec.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/ReservationSpec.java
@@ -76,4 +76,8 @@ public class ReservationSpec {
     public void setStatus(final ReservationSpecStatus status) {
         this.status = status;
     }
+
+    public LocalDate getEndDate() {
+        return this.period.getRentalEndDate();
+    }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/dto/response/UnterminatedReservationResponse.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/dto/response/UnterminatedReservationResponse.java
@@ -1,0 +1,31 @@
+package com.girigiri.kwrental.reservation.dto.response;
+
+import com.girigiri.kwrental.reservation.domain.Reservation;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class UnterminatedReservationResponse {
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<UnterminatedReservationSpecResponse> reservationSpecs;
+
+    private UnterminatedReservationResponse() {
+    }
+
+    private UnterminatedReservationResponse(final LocalDate startDate, final LocalDate endDate, final List<UnterminatedReservationSpecResponse> reservationSpecs) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.reservationSpecs = reservationSpecs;
+    }
+
+    public static UnterminatedReservationResponse from(final Reservation unterminatedReservation) {
+        final List<UnterminatedReservationSpecResponse> reservationSpecResponses = unterminatedReservation.getReservationSpecs().stream()
+                .map(UnterminatedReservationSpecResponse::from)
+                .toList();
+        return new UnterminatedReservationResponse(unterminatedReservation.getStartDate(), unterminatedReservation.getEndDate(), reservationSpecResponses);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/dto/response/UnterminatedReservationSpecResponse.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/dto/response/UnterminatedReservationSpecResponse.java
@@ -1,0 +1,35 @@
+package com.girigiri.kwrental.reservation.dto.response;
+
+import com.girigiri.kwrental.equipment.domain.Category;
+import com.girigiri.kwrental.equipment.domain.Equipment;
+import com.girigiri.kwrental.reservation.domain.ReservationSpec;
+import com.girigiri.kwrental.reservation.domain.ReservationSpecStatus;
+import lombok.Getter;
+
+@Getter
+public class UnterminatedReservationSpecResponse {
+
+    private Long id;
+
+    private Category category;
+    private String modelName;
+    private Integer rentalAmount;
+    private ReservationSpecStatus status;
+
+    private UnterminatedReservationSpecResponse() {
+    }
+
+    private UnterminatedReservationSpecResponse(final Long id, final Category category, final String modelName, final Integer rentalAmount, final ReservationSpecStatus status) {
+        this.id = id;
+        this.category = category;
+        this.modelName = modelName;
+        this.rentalAmount = rentalAmount;
+        this.status = status;
+    }
+
+    public static UnterminatedReservationSpecResponse from(final ReservationSpec reservationSpec) {
+        final Equipment equipment = reservationSpec.getEquipment();
+        return new UnterminatedReservationSpecResponse(
+                reservationSpec.getId(), equipment.getCategory(), equipment.getModelName(), reservationSpec.getAmount().getAmount(), reservationSpec.getStatus());
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/dto/response/UnterminatedReservationsResponse.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/dto/response/UnterminatedReservationsResponse.java
@@ -1,0 +1,26 @@
+package com.girigiri.kwrental.reservation.dto.response;
+
+import com.girigiri.kwrental.reservation.domain.Reservation;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UnterminatedReservationsResponse {
+
+    private List<UnterminatedReservationResponse> reservations;
+
+    private UnterminatedReservationsResponse() {
+    }
+
+    private UnterminatedReservationsResponse(final List<UnterminatedReservationResponse> reservations) {
+        this.reservations = reservations;
+    }
+
+    public static UnterminatedReservationsResponse from(final List<Reservation> unterminatedReservations) {
+        final List<UnterminatedReservationResponse> reservationResponses = unterminatedReservations.stream()
+                .map(UnterminatedReservationResponse::from)
+                .toList();
+        return new UnterminatedReservationsResponse(reservationResponses);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustom.java
@@ -16,4 +16,6 @@ public interface ReservationRepositoryCustom {
     Set<ReservationWithMemberNumber> findOverdueReservationWithSpecs(LocalDate returnDate);
 
     Set<ReservationWithMemberNumber> findReservationsWithSpecsByEndDate(LocalDate localDate);
+
+    Set<Reservation> findNotTerminatedReservationsByMemberId(Long memberId);
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -61,4 +61,16 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                 .where(reservationSpec.period.rentalEndDate.eq(endDate))
                 .fetch());
     }
+
+    @Override
+    public Set<Reservation> findNotTerminatedReservationsByMemberId(final Long memberId) {
+        return Set.copyOf(jpaQueryFactory
+                .selectFrom(reservation)
+                .join(reservation.reservationSpecs, reservationSpec).fetchJoin()
+                .join(reservationSpec.equipment).fetchJoin()
+                .where(reservation.memberId.eq(memberId)
+                        .and(reservation.terminated.isFalse()))
+                .fetch()
+        );
+    }
 }

--- a/src/test/java/com/girigiri/kwrental/inventory/domain/RentalPeriodTest.java
+++ b/src/test/java/com/girigiri/kwrental/inventory/domain/RentalPeriodTest.java
@@ -3,6 +3,8 @@ package com.girigiri.kwrental.inventory.domain;
 import com.girigiri.kwrental.inventory.exception.RentalDateException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.time.LocalDate;
 
@@ -92,4 +94,20 @@ class RentalPeriodTest {
                 () -> assertThat(legalReturn2).isTrue()
         );
     }
+
+    @ParameterizedTest
+    @CsvSource(value = {"0,2,1", "1,2,1", "1,3,0", "1,4,-1", "2,3,-1", "2,4,-1"})
+    void compareTo(int start, int end, int expect) {
+        // given
+        final LocalDate now = LocalDate.now();
+        final RentalPeriod period = new RentalPeriod(now.plusDays(1), now.plusDays(3));
+        final RentalPeriod other = new RentalPeriod(now.plusDays(start), now.plusDays(end));
+
+        // when
+        final int actual = period.compareTo(other);
+
+        // then
+        assertThat(actual).isEqualTo(expect);
+    }
+
 }

--- a/src/test/java/com/girigiri/kwrental/testsupport/fixture/ReservationFixture.java
+++ b/src/test/java/com/girigiri/kwrental/testsupport/fixture/ReservationFixture.java
@@ -18,6 +18,7 @@ public class ReservationFixture {
                 .name("대여자")
                 .phoneNumber("01012345678")
                 .memberId(0L)
-                .reservationSpecs(reservationSpecs);
+                .reservationSpecs(reservationSpecs)
+                .terminated(false);
     }
 }


### PR DESCRIPTION
<img width="867" alt="스크린샷 2023-05-11 오후 6 42 05" src="https://github.com/KW-GIRIGIRI/kw-rental-backend/assets/87690744/12f2bab3-7550-4292-a805-33376636b6ce">

내가 신청한 대여 예약 중, 빌려간 모든 품목이 반납 상태(정상 반납 + 비정상 반납)이 아닌 대여 예약을 모두 조회하는 API이다.

즉 사용자가 더 해야할 행동이 존재하는 지를 기준으로 종결 의미를 나눴다.
다음은 종결되지 않은 상황들이다.
(아직 빌려가지 않았으면 사용자는 수령해야 한다. 대여중이면 추후에 반납해야 한다. 연체중이면 연체된 품목을 반납해야 한다.)

그 외 상황들은 사용자가 특별히 더 취할 행동이 없다. 다음 상황들은 종결된 대여 예약의 예시다.
(모두 정상 반납, 일부가 파손, 일부가 분실, 모두 취소, 연체 중인 품목을 반납)