### PR TITLE
품목 히스토리 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/item.adoc
+++ b/src/docs/asciidoc/item.adoc
@@ -29,3 +29,9 @@ operation::admin_deleteItem[snippets='http-request,http-response']
 === 현 시점 수령 가능한 품목 조회 API
 
 operation::admin_getAcceptableItems[snippets='http-request,http-response']
+
+=== 관리자 품목 히스토리 페이지 조회 API (기자재 히스토리)
+
+`size` 는 한 페이지에 담길 데이터 갯수
+
+operation::admin_getItemHistories[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/item/controller/AdminItemController.java
+++ b/src/main/java/com/girigiri/kwrental/item/controller/AdminItemController.java
@@ -1,15 +1,24 @@
 package com.girigiri.kwrental.item.controller;
 
+import com.girigiri.kwrental.item.dto.request.ItemHistoryRequest;
 import com.girigiri.kwrental.item.dto.request.ItemPropertyNumberRequest;
 import com.girigiri.kwrental.item.dto.request.ItemRentalAvailableRequest;
 import com.girigiri.kwrental.item.dto.request.SaveOrUpdateItemsRequest;
+import com.girigiri.kwrental.item.dto.response.ItemHistoriesResponse;
+import com.girigiri.kwrental.item.dto.response.ItemHistory;
 import com.girigiri.kwrental.item.dto.response.ItemsResponse;
 import com.girigiri.kwrental.item.service.ItemService;
+import com.girigiri.kwrental.util.EndPointUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/admin/items")
@@ -50,5 +59,15 @@ public class AdminItemController {
     @GetMapping("/rentalAvailability")
     public ItemsResponse getRentalAvailable(final Long equipmentId) {
         return itemService.getRentalAvailableItems(equipmentId);
+    }
+
+    @GetMapping("/histories")
+    public ItemHistoriesResponse getHistories(
+            @PageableDefault(sort = {"id"}, direction = Sort.Direction.DESC) final Pageable pageable,
+            @Validated final ItemHistoryRequest itemHistoryRequest) {
+        final Page<ItemHistory> page = itemService.getItemHistories(
+                pageable, itemHistoryRequest.category(), itemHistoryRequest.from(), itemHistoryRequest.to());
+        final List<String> allPageEndPoints = EndPointUtils.createAllPageEndPoints(page);
+        return ItemHistoriesResponse.of(page, allPageEndPoints);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/item/dto/request/ItemHistoryRequest.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/request/ItemHistoryRequest.java
@@ -1,0 +1,13 @@
+package com.girigiri.kwrental.item.dto.request;
+
+import com.girigiri.kwrental.equipment.domain.Category;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record ItemHistoryRequest(
+        Category category,
+        @NotNull LocalDate from,
+        @NotNull LocalDate to
+) {
+}

--- a/src/main/java/com/girigiri/kwrental/item/dto/response/EquipmentItemDto.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/response/EquipmentItemDto.java
@@ -1,0 +1,18 @@
+package com.girigiri.kwrental.item.dto.response;
+
+import com.girigiri.kwrental.equipment.domain.Category;
+import lombok.Getter;
+
+@Getter
+public class EquipmentItemDto {
+
+    private final String modelName;
+    private final Category category;
+    private final String propertyNumber;
+
+    public EquipmentItemDto(final String modelName, final Category category, final String propertyNumber) {
+        this.modelName = modelName;
+        this.category = category;
+        this.propertyNumber = propertyNumber;
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/item/dto/response/ItemHistoriesResponse.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/response/ItemHistoriesResponse.java
@@ -1,0 +1,24 @@
+package com.girigiri.kwrental.item.dto.response;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class ItemHistoriesResponse {
+
+    private final List<ItemHistory> histories;
+    private final Integer page;
+    private final List<String> endpoints;
+
+    private ItemHistoriesResponse(final List<ItemHistory> histories, final Integer page, final List<String> endpoints) {
+        this.histories = histories;
+        this.page = page;
+        this.endpoints = endpoints;
+    }
+
+    public static ItemHistoriesResponse of(final Page<ItemHistory> page, final List<String> allPageEndPoints) {
+        return new ItemHistoriesResponse(page.getContent(), page.getNumber(), allPageEndPoints);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/item/dto/response/ItemHistory.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/response/ItemHistory.java
@@ -1,0 +1,24 @@
+package com.girigiri.kwrental.item.dto.response;
+
+import com.girigiri.kwrental.equipment.domain.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemHistory {
+
+    private final Category category;
+    private final String modelName;
+    private final String propertyNumber;
+    private final Integer normalRentalCount;
+    private final Integer abnormalRentalCount;
+
+    public ItemHistory(final Category category, final String modelName, final String propertyNumber, final Integer normalRentalCount, final Integer abnormalRentalCount) {
+        this.category = category;
+        this.modelName = modelName;
+        this.propertyNumber = propertyNumber;
+        this.normalRentalCount = normalRentalCount;
+        this.abnormalRentalCount = abnormalRentalCount;
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/item/dto/response/RentalCountsDto.java
+++ b/src/main/java/com/girigiri/kwrental/item/dto/response/RentalCountsDto.java
@@ -1,0 +1,17 @@
+package com.girigiri.kwrental.item.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class RentalCountsDto {
+
+    private final String propertyNumber;
+    private final Integer normalRentalCount;
+    private final Integer abnormalRentalCount;
+
+    public RentalCountsDto(final String propertyNumber, final Integer normalRentalCount, final Integer abnormalRentalCount) {
+        this.propertyNumber = propertyNumber;
+        this.normalRentalCount = normalRentalCount;
+        this.abnormalRentalCount = abnormalRentalCount;
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/item/repository/ItemQueryDslRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/item/repository/ItemQueryDslRepositoryCustom.java
@@ -1,6 +1,10 @@
 package com.girigiri.kwrental.item.repository;
 
+import com.girigiri.kwrental.equipment.domain.Category;
 import com.girigiri.kwrental.item.domain.Item;
+import com.girigiri.kwrental.item.dto.response.EquipmentItemDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Set;
@@ -16,4 +20,6 @@ public interface ItemQueryDslRepositoryCustom {
     List<Item> findByEquipmentIds(Set<Long> equipmentIds);
 
     long deleteByPropertyNumbers(List<String> propertyNumbers);
+
+    Page<EquipmentItemDto> findEquipmentItem(Pageable pageable, Category category);
 }

--- a/src/main/java/com/girigiri/kwrental/item/service/ItemService.java
+++ b/src/main/java/com/girigiri/kwrental/item/service/ItemService.java
@@ -184,7 +184,7 @@ public class ItemService {
         return itemDtosPage.map(it -> mapToHistory(it, rentalCountsByPropertyNumbers.get(it.getPropertyNumber())));
     }
 
-    private static ItemHistory mapToHistory(final EquipmentItemDto equipmentItemDto, final RentalCountsDto rentalCountsDto) {
+    private ItemHistory mapToHistory(final EquipmentItemDto equipmentItemDto, final RentalCountsDto rentalCountsDto) {
         final ItemHistoryBuilder builder = ItemHistory.builder()
                 .modelName(equipmentItemDto.getModelName())
                 .category(equipmentItemDto.getCategory())

--- a/src/main/java/com/girigiri/kwrental/item/service/RentedItemService.java
+++ b/src/main/java/com/girigiri/kwrental/item/service/RentedItemService.java
@@ -1,9 +1,15 @@
 package com.girigiri.kwrental.item.service;
 
+import com.girigiri.kwrental.item.dto.response.RentalCountsDto;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Set;
 
 public interface RentedItemService {
 
     Set<String> getRentedPropertyNumbers(Long equipmentId, LocalDateTime date);
+
+    Map<String, RentalCountsDto> getRentalCountsByPropertyNumbersBetweenDate(Set<String> propertyNumbers, LocalDate from, LocalDate to);
 }

--- a/src/main/java/com/girigiri/kwrental/rental/domain/RentalSpecStatus.java
+++ b/src/main/java/com/girigiri/kwrental/rental/domain/RentalSpecStatus.java
@@ -1,8 +1,17 @@
 package com.girigiri.kwrental.rental.domain;
 
+import java.util.Arrays;
+import java.util.List;
+
 public enum RentalSpecStatus {
 
     RENTED, RETURNED, LOST, BROKEN, OVERDUE_RENTED, OVERDUE_RETURNED;
+
+    public static List<RentalSpecStatus> getAbnormalReturnedStatus() {
+        return Arrays.stream(RentalSpecStatus.values())
+                .filter(RentalSpecStatus::isAbnormalReturned)
+                .toList();
+    }
 
     public boolean isReturnedOrAbnormalReturned() {
         return this == RETURNED || isAbnormalReturned();

--- a/src/main/java/com/girigiri/kwrental/rental/domain/RentalSpecStatus.java
+++ b/src/main/java/com/girigiri/kwrental/rental/domain/RentalSpecStatus.java
@@ -17,7 +17,11 @@ public enum RentalSpecStatus {
         return this == RETURNED || isAbnormalReturned();
     }
 
-    private boolean isAbnormalReturned() {
+    public boolean isAbnormalReturned() {
         return this == LOST || this == BROKEN || this == OVERDUE_RETURNED;
+    }
+
+    public boolean isNormalReturned() {
+        return this == RETURNED;
     }
 }

--- a/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.girigiri.kwrental.rental.repository;
 
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.girigiri.kwrental.rental.repository.dto.RentalDto;
+import com.girigiri.kwrental.rental.repository.dto.RentalSpecStatuesPerPropertyNumber;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,4 +19,6 @@ public interface RentalSpecRepositoryCustom {
     List<RentalSpec> findByReservationId(Long reservationId);
 
     List<RentalDto> findRentalDtosBetweenDate(Long memberId, LocalDate from, LocalDate to);
+
+    List<RentalSpecStatuesPerPropertyNumber> findStatusesByPropertyNumbersBetweenDate(Set<String> propertyNumbers, LocalDate from, LocalDate to);
 }

--- a/src/main/java/com/girigiri/kwrental/rental/repository/dto/RentalSpecStatuesPerPropertyNumber.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/dto/RentalSpecStatuesPerPropertyNumber.java
@@ -1,0 +1,30 @@
+package com.girigiri.kwrental.rental.repository.dto;
+
+import com.girigiri.kwrental.rental.domain.RentalSpecStatus;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RentalSpecStatuesPerPropertyNumber {
+
+    private final String propertyNumber;
+    private final List<RentalSpecStatus> statuses;
+
+    public RentalSpecStatuesPerPropertyNumber(final String propertyNumber, final List<RentalSpecStatus> statuses) {
+        this.propertyNumber = propertyNumber;
+        this.statuses = statuses;
+    }
+
+    public int getNormalReturnedCount() {
+        return Math.toIntExact(statuses.stream()
+                .filter(RentalSpecStatus::isNormalReturned)
+                .count());
+    }
+
+    public int getAbnormalReturnedCount() {
+        return Math.toIntExact(statuses.stream()
+                .filter(RentalSpecStatus::isAbnormalReturned)
+                .count());
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/rental/service/RentedItemServiceImpl.java
+++ b/src/main/java/com/girigiri/kwrental/rental/service/RentedItemServiceImpl.java
@@ -1,20 +1,24 @@
 package com.girigiri.kwrental.rental.service;
 
+import com.girigiri.kwrental.item.dto.response.RentalCountsDto;
 import com.girigiri.kwrental.item.service.RentedItemService;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.girigiri.kwrental.rental.repository.RentalSpecRepository;
+import com.girigiri.kwrental.rental.repository.dto.RentalSpecStatuesPerPropertyNumber;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 public class RentedItemServiceImpl implements RentedItemService {
 
-    private RentalSpecRepository rentalSpecRepository;
+    private final RentalSpecRepository rentalSpecRepository;
 
     public RentedItemServiceImpl(final RentalSpecRepository rentalSpecRepository) {
         this.rentalSpecRepository = rentalSpecRepository;
@@ -27,5 +31,21 @@ public class RentedItemServiceImpl implements RentedItemService {
                 .stream()
                 .map(RentalSpec::getPropertyNumber)
                 .collect(Collectors.toSet());
+    }
+
+    @Override
+    @Transactional(readOnly = true, propagation = Propagation.MANDATORY)
+    public Map<String, RentalCountsDto> getRentalCountsByPropertyNumbersBetweenDate(final Set<String> propertyNumbers, final LocalDate from, final LocalDate to) {
+        return rentalSpecRepository.findStatusesByPropertyNumbersBetweenDate(propertyNumbers, from, to)
+                .stream()
+                .collect(Collectors.toMap(RentalSpecStatuesPerPropertyNumber::getPropertyNumber, this::mapToRentalCountsDto));
+    }
+
+    private RentalCountsDto mapToRentalCountsDto(final RentalSpecStatuesPerPropertyNumber rentalSpecStatues) {
+        return new RentalCountsDto(
+                rentalSpecStatues.getPropertyNumber(),
+                rentalSpecStatues.getNormalReturnedCount(),
+                rentalSpecStatues.getAbnormalReturnedCount()
+        );
     }
 }

--- a/src/main/java/com/girigiri/kwrental/util/EndPointUtils.java
+++ b/src/main/java/com/girigiri/kwrental/util/EndPointUtils.java
@@ -1,9 +1,5 @@
 package com.girigiri.kwrental.util;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -12,6 +8,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Component
 public class EndPointUtils {
@@ -49,6 +50,7 @@ public class EndPointUtils {
     }
 
     private static String sortToString(final Sort sort) {
+        if (sort.isEmpty()) return "";
         StringBuilder builder = new StringBuilder();
 
         for (Order order : sort) {

--- a/src/main/java/com/girigiri/kwrental/util/QueryDSLUtils.java
+++ b/src/main/java/com/girigiri/kwrental/util/QueryDSLUtils.java
@@ -1,9 +1,6 @@
 package com.girigiri.kwrental.util;
 
 
-import static com.querydsl.core.types.Order.ASC;
-import static com.querydsl.core.types.Order.DESC;
-
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
@@ -16,6 +13,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 
+import static com.querydsl.core.types.Order.ASC;
+import static com.querydsl.core.types.Order.DESC;
+
 public class QueryDSLUtils {
 
     public static Predicate isContains(final String input, StringPath path) {
@@ -26,8 +26,8 @@ public class QueryDSLUtils {
         return t == null ? null : expression.eq(t);
     }
 
-    public static <T> JPAQuery<T> setPageable(final JPAQuery<T> query, final Path<?> path, final Pageable pageable) {
-        return query
+    public static <T> void setPageable(final JPAQuery<T> query, final Path<?> path, final Pageable pageable) {
+        query
                 .orderBy(getOrderSpecFrom(pageable.getSort(), path))
                 .limit(pageable.getPageSize())
                 .offset(getOffsetFrom(pageable));

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -1,0 +1,6 @@
+spring:
+  flyway:
+    enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: create

--- a/src/test/java/com/girigiri/kwrental/rental/domain/RentalSpecStatusTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/domain/RentalSpecStatusTest.java
@@ -1,0 +1,31 @@
+package com.girigiri.kwrental.rental.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RentalSpecStatusTest {
+
+    @ParameterizedTest
+    @CsvSource({"RENTED,false", "RETURNED,true", "LOST,true", "BROKEN,true", "OVERDUE_RENTED,false", "OVERDUE_RETURNED,true"})
+    void getAbnormalReturnedStatus(final RentalSpecStatus status, final boolean expect) {
+        // given, when
+        final boolean actual = status.isReturnedOrAbnormalReturned();
+
+        // then
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    void isReturnedOrAbnormalReturned() {
+        // given, when
+        final List<RentalSpecStatus> actual = RentalSpecStatus.getAbnormalReturnedStatus();
+
+        // then
+        assertThat(actual).containsExactlyInAnyOrder(RentalSpecStatus.LOST, RentalSpecStatus.BROKEN, RentalSpecStatus.OVERDUE_RETURNED);
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
@@ -141,22 +141,32 @@ class RentalSpecRepositoryTest {
         final LocalDate now = LocalDate.now();
         final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment1).period(new RentalPeriod(now, now.plusDays(1))).build();
         final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(now, now.plusDays(1))).build();
-        final Reservation reservation = reservationRepository.save(ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).build());
+        final Reservation reservation1 = reservationRepository.save(ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).build());
 
-        final RentalSpec rentalSpec1 = RentalSpecFixture.builder().propertyNumber("11111111").reservationSpecId(reservationSpec1.getId()).reservationId(reservation.getId())
+        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(equipment1).period(new RentalPeriod(now.plusDays(1), now.plusDays(2))).build();
+        final ReservationSpec reservationSpec4 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(now.plusDays(1), now.plusDays(2))).build();
+        final Reservation reservation2 = reservationRepository.save(ReservationFixture.builder(List.of(reservationSpec3, reservationSpec4)).build());
+
+        final String propertyNumber1 = "11111111";
+        final String propertyNumber2 = "22222222";
+        final RentalSpec rentalSpec1 = RentalSpecFixture.builder().propertyNumber(propertyNumber1).reservationSpecId(reservationSpec1.getId()).reservationId(reservation1.getId())
                 .status(RentalSpecStatus.RETURNED).build();
-        final RentalSpec rentalSpec2 = RentalSpecFixture.builder().propertyNumber("22222222").reservationSpecId(reservationSpec2.getId()).reservationId(reservation.getId())
+        final RentalSpec rentalSpec2 = RentalSpecFixture.builder().propertyNumber(propertyNumber2).reservationSpecId(reservationSpec2.getId()).reservationId(reservation1.getId())
                 .status(RentalSpecStatus.LOST).build();
-        rentalSpecRepository.saveAll(List.of(rentalSpec1, rentalSpec2));
+        final RentalSpec rentalSpec3 = RentalSpecFixture.builder().propertyNumber(propertyNumber1).reservationSpecId(reservationSpec3.getId()).reservationId(reservation2.getId())
+                .status(RentalSpecStatus.BROKEN).build();
+        final RentalSpec rentalSpec4 = RentalSpecFixture.builder().propertyNumber(propertyNumber2).reservationSpecId(reservationSpec4.getId()).reservationId(reservation2.getId())
+                .status(RentalSpecStatus.LOST).build();
+        rentalSpecRepository.saveAll(List.of(rentalSpec1, rentalSpec2, rentalSpec3, rentalSpec4));
 
         // when
         final List<RentalSpecStatuesPerPropertyNumber> rentalCountsDtos = rentalSpecRepository.findStatusesByPropertyNumbersBetweenDate(
-                Set.of(rentalSpec1.getPropertyNumber(), rentalSpec2.getPropertyNumber()), now, now.plusDays(1));
+                Set.of(rentalSpec1.getPropertyNumber(), rentalSpec2.getPropertyNumber()), now, now.plusDays(2));
 
         // then
         assertThat(rentalCountsDtos).usingRecursiveFieldByFieldElementComparator()
                 .containsExactlyInAnyOrder(
-                        new RentalSpecStatuesPerPropertyNumber(rentalSpec1.getPropertyNumber(), List.of(RentalSpecStatus.RETURNED)),
-                        new RentalSpecStatuesPerPropertyNumber(rentalSpec2.getPropertyNumber(), List.of(RentalSpecStatus.LOST)));
+                        new RentalSpecStatuesPerPropertyNumber(rentalSpec1.getPropertyNumber(), List.of(RentalSpecStatus.RETURNED, RentalSpecStatus.BROKEN)),
+                        new RentalSpecStatuesPerPropertyNumber(rentalSpec2.getPropertyNumber(), List.of(RentalSpecStatus.LOST, RentalSpecStatus.LOST)));
     }
 }

--- a/src/test/java/com/girigiri/kwrental/rental/service/RentedItemServiceImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/service/RentedItemServiceImplTest.java
@@ -1,6 +1,9 @@
 package com.girigiri.kwrental.rental.service;
 
+import com.girigiri.kwrental.item.dto.response.RentalCountsDto;
+import com.girigiri.kwrental.rental.domain.RentalSpecStatus;
 import com.girigiri.kwrental.rental.repository.RentalSpecRepository;
+import com.girigiri.kwrental.rental.repository.dto.RentalSpecStatuesPerPropertyNumber;
 import com.girigiri.kwrental.testsupport.fixture.RentalSpecFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,11 +12,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,5 +45,26 @@ class RentedItemServiceImplTest {
 
         // then
         assertThat(rentedPropertyNumbers).containsOnly("12345678");
+    }
+
+    @Test
+    @DisplayName("특정 기간에 자산 번호에 해당하는 대여 상태를 조회한다.")
+    void getRentalCountsByPropertyNumbersBetweenDate() {
+        // given
+        final RentalSpecStatuesPerPropertyNumber statuses1 = new RentalSpecStatuesPerPropertyNumber("11111111", List.of(RentalSpecStatus.RETURNED, RentalSpecStatus.RETURNED, RentalSpecStatus.LOST));
+        final RentalSpecStatuesPerPropertyNumber statuses2 = new RentalSpecStatuesPerPropertyNumber("22222222", List.of(RentalSpecStatus.BROKEN, RentalSpecStatus.LOST));
+        given(rentalSpecRepository.findStatusesByPropertyNumbersBetweenDate(anySet(), any(), any()))
+                .willReturn(List.of(statuses1, statuses2));
+
+        // when
+        final LocalDate now = LocalDate.now();
+        final Map<String, RentalCountsDto> rentalCountsByPropertyNumbers =
+                rentedItemService.getRentalCountsByPropertyNumbersBetweenDate(Set.of(statuses1.getPropertyNumber(), statuses2.getPropertyNumber()), now.minusDays(1), now);
+
+        // then
+        assertAll(
+                () -> assertThat(rentalCountsByPropertyNumbers.get(statuses1.getPropertyNumber())).usingRecursiveComparison().isEqualTo(new RentalCountsDto(statuses1.getPropertyNumber(), 2, 1)),
+                () -> assertThat(rentalCountsByPropertyNumbers.get(statuses2.getPropertyNumber())).usingRecursiveComparison().isEqualTo(new RentalCountsDto(statuses2.getPropertyNumber(), 0, 2))
+        );
     }
 }


### PR DESCRIPTION
품목 목록을 페이징해서 조회한다. 이때 각 품목의 정상 대여 횟수와 비정상 대여 횟수를 카운트해서 같이 보여줘야 한다.
자세한 구현 사항은 아래 코멘트 참고