### PR TITLE
품목 사용 이력 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/rental.adoc
+++ b/src/docs/asciidoc/rental.adoc
@@ -37,3 +37,7 @@ operation::admin_returnRentals[snippets='http-request,http-response']
 === 내 대여 이력 조회
 
 operation::getRentals[snippets='http-request,http-response']
+
+=== 품목 사용 이력 조회
+
+operation::admin_getReturnedRentalSpecsByPropertyNumber[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/RentalDateTime.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/RentalDateTime.java
@@ -1,0 +1,49 @@
+package com.girigiri.kwrental.inventory.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Getter
+@Embeddable
+public class RentalDateTime {
+
+    private Instant instant;
+
+    protected RentalDateTime() {
+    }
+
+    private RentalDateTime(final Instant instant) {
+        this.instant = instant;
+    }
+
+    public static RentalDateTime now() {
+        return new RentalDateTime(Instant.now());
+    }
+
+    public LocalDateTime toLocalDateTime() {
+        return LocalDateTime.ofInstant(this.instant, ZoneId.systemDefault());
+    }
+
+    public RentalDateTime calculateDay(final int days) {
+        final LocalDate date = days < 0 ? toLocalDate().minusDays(days) : toLocalDate().plusDays(days);
+        return RentalDateTime.from(date);
+    }
+
+    public static RentalDateTime from(final LocalDate localDate) {
+        LocalDateTime localDateTime = localDate.atStartOfDay();
+        return RentalDateTime.from(localDateTime);
+    }
+
+    public static RentalDateTime from(final LocalDateTime localDateTime) {
+        return new RentalDateTime(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    public LocalDate toLocalDate() {
+        return LocalDate.ofInstant(this.instant, ZoneId.systemDefault());
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/RentalDateTime.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/RentalDateTime.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 
 @Getter
 @Embeddable
@@ -18,7 +19,7 @@ public class RentalDateTime {
     }
 
     private RentalDateTime(final Instant instant) {
-        this.instant = instant;
+        this.instant = instant.truncatedTo(ChronoUnit.MILLIS);
     }
 
     public static RentalDateTime now() {
@@ -26,7 +27,7 @@ public class RentalDateTime {
     }
 
     public LocalDateTime toLocalDateTime() {
-        return LocalDateTime.ofInstant(this.instant, ZoneId.systemDefault());
+        return LocalDateTime.ofInstant(this.instant, ZoneId.systemDefault()).truncatedTo(ChronoUnit.MILLIS);
     }
 
     public RentalDateTime calculateDay(final int days) {

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
@@ -23,7 +23,11 @@ public class RentalPeriod implements Comparable<RentalPeriod> {
     protected RentalPeriod() {
     }
 
-    public RentalPeriod(LocalDate rentalStartDate, LocalDate rentalEndDate) {
+    public RentalPeriod(final RentalDateTime start, final RentalDateTime end) {
+        this(start.toLocalDate(), end.toLocalDate());
+    }
+
+    public RentalPeriod(final LocalDate rentalStartDate, final LocalDate rentalEndDate) {
         if (rentalStartDate == null || rentalEndDate == null) {
             throw new RentalDateException("일자에 빈 값이 올 수 없습니다.");
         }
@@ -33,6 +37,7 @@ public class RentalPeriod implements Comparable<RentalPeriod> {
         this.rentalStartDate = rentalStartDate;
         this.rentalEndDate = rentalEndDate;
     }
+
 
     public Integer getRentalDays() {
         return (int) rentalStartDate.until(rentalEndDate, ChronoUnit.DAYS);

--- a/src/main/java/com/girigiri/kwrental/rental/controller/AdminRentalController.java
+++ b/src/main/java/com/girigiri/kwrental/rental/controller/AdminRentalController.java
@@ -2,6 +2,7 @@ package com.girigiri.kwrental.rental.controller;
 
 import com.girigiri.kwrental.rental.dto.request.CreateRentalRequest;
 import com.girigiri.kwrental.rental.dto.request.ReturnRentalRequest;
+import com.girigiri.kwrental.rental.dto.response.RentalSpecsByItemResponse;
 import com.girigiri.kwrental.rental.dto.response.ReservationsWithRentalSpecsByEndDateResponse;
 import com.girigiri.kwrental.rental.dto.response.reservationsWithRentalSpecs.ReservationsWithRentalSpecsAndMemberNumberResponse;
 import com.girigiri.kwrental.rental.service.RentalService;
@@ -45,5 +46,10 @@ public class AdminRentalController {
     public ResponseEntity<?> returnRental(@RequestBody final ReturnRentalRequest returnRentalRequest) {
         rentalService.returnRental(returnRentalRequest);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping(value = "/returns", params = "propertyNumber")
+    public RentalSpecsByItemResponse getReturnsByPropertyNumber(final String propertyNumber) {
+        return rentalService.getReturnedRentalSpecs(propertyNumber);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/rental/domain/RentalSpec.java
+++ b/src/main/java/com/girigiri/kwrental/rental/domain/RentalSpec.java
@@ -1,5 +1,6 @@
 package com.girigiri.kwrental.rental.domain;
 
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,14 +34,18 @@ public class RentalSpec {
     private RentalSpecStatus status = RentalSpecStatus.RENTED;
 
     @CreatedDate
-    private LocalDateTime acceptDateTime;
+    @Embedded
+    @AttributeOverride(name = "instant", column = @Column(name = "accept_date_time"))
+    private RentalDateTime acceptDateTime;
 
-    private LocalDateTime returnDateTime;
+    @Embedded
+    @AttributeOverride(name = "instant", column = @Column(name = "return_date_time"))
+    private RentalDateTime returnDateTime;
 
     protected RentalSpec() {
     }
 
-    private RentalSpec(final Long id, final Long reservationSpecId, final Long reservationId, final String propertyNumber, final RentalSpecStatus status, final LocalDateTime acceptDateTime, final LocalDateTime returnDateTime) {
+    private RentalSpec(final Long id, final Long reservationSpecId, final Long reservationId, final String propertyNumber, final RentalSpecStatus status, final RentalDateTime acceptDateTime, final RentalDateTime returnDateTime) {
         this.id = id;
         this.reservationSpecId = reservationSpecId;
         this.reservationId = reservationId;
@@ -60,7 +65,7 @@ public class RentalSpec {
 
     public void setReturnDateTimeIfAnyReturned(final LocalDateTime returnDateTime) {
         if (this.status.isReturnedOrAbnormalReturned()) {
-            this.returnDateTime = returnDateTime;
+            this.returnDateTime = RentalDateTime.from(returnDateTime);
         }
     }
 

--- a/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecByItemResponse.java
+++ b/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecByItemResponse.java
@@ -29,8 +29,8 @@ public class RentalSpecByItemResponse {
     public static RentalSpecByItemResponse from(final RentalSpecWithName rentalSpecWithName) {
         return RentalSpecByItemResponse.builder()
                 .status(rentalSpecWithName.getStatus().isAbnormalReturned() ? "불량 반납" : "정상 반납")
-                .acceptDate(rentalSpecWithName.getAcceptDateTime().toLocalDate())
-                .returnDate(rentalSpecWithName.getReturnDateTime().toLocalDate())
+                .acceptDate(LocalDate.from(rentalSpecWithName.getAcceptDateTime()))
+                .returnDate(LocalDate.from(rentalSpecWithName.getReturnDateTime()))
                 .name(rentalSpecWithName.getName())
                 .reason(rentalSpecWithName.getStatus().name())
                 .build();

--- a/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecByItemResponse.java
+++ b/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecByItemResponse.java
@@ -1,0 +1,38 @@
+package com.girigiri.kwrental.rental.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class RentalSpecByItemResponse {
+
+    private String status;
+    private LocalDate acceptDate;
+    private LocalDate returnDate;
+    private String name;
+    private String reason;
+
+    private RentalSpecByItemResponse() {
+    }
+
+    public RentalSpecByItemResponse(final String status, final LocalDate acceptDate, final LocalDate returnDate, final String name, final String reason) {
+        this.status = status;
+        this.acceptDate = acceptDate;
+        this.returnDate = returnDate;
+        this.name = name;
+        this.reason = reason;
+    }
+
+    public static RentalSpecByItemResponse from(final RentalSpecWithName rentalSpecWithName) {
+        return RentalSpecByItemResponse.builder()
+                .status(rentalSpecWithName.getStatus().isAbnormalReturned() ? "불량 반납" : "정상 반납")
+                .acceptDate(rentalSpecWithName.getAcceptDateTime().toLocalDate())
+                .returnDate(rentalSpecWithName.getReturnDateTime().toLocalDate())
+                .name(rentalSpecWithName.getName())
+                .reason(rentalSpecWithName.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecWithName.java
+++ b/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecWithName.java
@@ -1,0 +1,22 @@
+package com.girigiri.kwrental.rental.dto.response;
+
+import com.girigiri.kwrental.rental.domain.RentalSpecStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class RentalSpecWithName {
+
+    private final String name;
+    private final LocalDateTime acceptDateTime;
+    private final LocalDateTime returnDateTime;
+    private final RentalSpecStatus status;
+
+    public RentalSpecWithName(final String name, final LocalDateTime acceptDateTime, final LocalDateTime returnDateTime, final RentalSpecStatus status) {
+        this.name = name;
+        this.acceptDateTime = acceptDateTime;
+        this.returnDateTime = returnDateTime;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecWithName.java
+++ b/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecWithName.java
@@ -1,5 +1,6 @@
 package com.girigiri.kwrental.rental.dto.response;
 
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.rental.domain.RentalSpecStatus;
 import lombok.Getter;
 
@@ -13,7 +14,11 @@ public class RentalSpecWithName {
     private final LocalDateTime returnDateTime;
     private final RentalSpecStatus status;
 
-    public RentalSpecWithName(final String name, final LocalDateTime acceptDateTime, final LocalDateTime returnDateTime, final RentalSpecStatus status) {
+    public RentalSpecWithName(final String name, final RentalDateTime acceptDateTime, final RentalDateTime returnDateTime, final RentalSpecStatus status) {
+        this(name, acceptDateTime == null ? null : acceptDateTime.toLocalDateTime(), returnDateTime == null ? null : returnDateTime.toLocalDateTime(), status);
+    }
+
+    private RentalSpecWithName(final String name, final LocalDateTime acceptDateTime, final LocalDateTime returnDateTime, final RentalSpecStatus status) {
         this.name = name;
         this.acceptDateTime = acceptDateTime;
         this.returnDateTime = returnDateTime;

--- a/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecsByItemResponse.java
+++ b/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalSpecsByItemResponse.java
@@ -1,0 +1,24 @@
+package com.girigiri.kwrental.rental.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RentalSpecsByItemResponse {
+    private List<RentalSpecByItemResponse> rentalSpecs;
+
+    private RentalSpecsByItemResponse() {
+    }
+
+    private RentalSpecsByItemResponse(final List<RentalSpecByItemResponse> rentalSpecs) {
+        this.rentalSpecs = rentalSpecs;
+    }
+
+    public static RentalSpecsByItemResponse from(final List<RentalSpecWithName> rentalSpecWithNames) {
+        final List<RentalSpecByItemResponse> rentalSpecByItemResponses = rentalSpecWithNames.stream()
+                .map(RentalSpecByItemResponse::from)
+                .toList();
+        return new RentalSpecsByItemResponse(rentalSpecByItemResponses);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/rental/dto/response/overduereservations/OverdueReservationResponse.java
+++ b/src/main/java/com/girigiri/kwrental/rental/dto/response/overduereservations/OverdueReservationResponse.java
@@ -5,7 +5,7 @@ import com.girigiri.kwrental.reservation.domain.Reservation;
 import com.girigiri.kwrental.reservation.repository.dto.ReservationWithMemberNumber;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -16,13 +16,13 @@ public class OverdueReservationResponse {
     private Long reservationId;
     private String name;
     private String memberNumber;
-    private LocalDateTime returnDate;
+    private Instant returnDate;
     private List<OverdueReservationSpecResponse> reservationSpecs;
 
     private OverdueReservationResponse() {
     }
 
-    private OverdueReservationResponse(final Long reservationId, final String name, final String memberNumber, final LocalDateTime returnDate, final List<OverdueReservationSpecResponse> reservationSpecs) {
+    private OverdueReservationResponse(final Long reservationId, final String name, final String memberNumber, final Instant returnDate, final List<OverdueReservationSpecResponse> reservationSpecs) {
         this.reservationId = reservationId;
         this.name = name;
         this.memberNumber = memberNumber;
@@ -34,7 +34,7 @@ public class OverdueReservationResponse {
         final Reservation reservation = reservationWithMemberNumber.getReservation();
         final List<OverdueReservationSpecResponse> overdueReservationSpecResponses = mapToReservationSpecResponse(rentalSpecs, reservation);
         return new OverdueReservationResponse(reservation.getId(), reservation.getName(),
-                reservationWithMemberNumber.getMemberNumber(), reservation.getAcceptDateTime(), overdueReservationSpecResponses);
+                reservationWithMemberNumber.getMemberNumber(), reservation.getAcceptDateTime().getInstant(), overdueReservationSpecResponses);
     }
 
     private static List<OverdueReservationSpecResponse> mapToReservationSpecResponse(final List<RentalSpec> rentalSpecs, final Reservation reservation) {

--- a/src/main/java/com/girigiri/kwrental/rental/dto/response/reservationsWithRentalSpecs/ReservationWithRentalSpecsResponse.java
+++ b/src/main/java/com/girigiri/kwrental/rental/dto/response/reservationsWithRentalSpecs/ReservationWithRentalSpecsResponse.java
@@ -5,7 +5,7 @@ import com.girigiri.kwrental.reservation.domain.Reservation;
 import com.girigiri.kwrental.reservation.repository.dto.ReservationWithMemberNumber;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -17,13 +17,13 @@ public class ReservationWithRentalSpecsResponse {
     private Long reservationId;
     private String name;
     private String memberNumber;
-    private LocalDateTime acceptDateTime;
+    private Instant acceptDateTime;
     private List<ReservationSpecWithRentalSpecsResponse> reservationSpecs;
 
     private ReservationWithRentalSpecsResponse() {
     }
 
-    private ReservationWithRentalSpecsResponse(final Long reservationId, final String name, final String memberNumber, final LocalDateTime acceptDateTime, final List<ReservationSpecWithRentalSpecsResponse> reservationSpecs) {
+    private ReservationWithRentalSpecsResponse(final Long reservationId, final String name, final String memberNumber, final Instant acceptDateTime, final List<ReservationSpecWithRentalSpecsResponse> reservationSpecs) {
         this.reservationId = reservationId;
         this.name = name;
         this.memberNumber = memberNumber;
@@ -33,9 +33,10 @@ public class ReservationWithRentalSpecsResponse {
 
     public static ReservationWithRentalSpecsResponse of(final ReservationWithMemberNumber reservationWithMemberNumber, final List<RentalSpec> rentalSpecs) {
         final Reservation reservation = reservationWithMemberNumber.getReservation();
-        final List<ReservationSpecWithRentalSpecsResponse> reservationSpecWithRentalSpecsRespons = mapToReservationSpecWithRentalSpecResponse(rentalSpecs, reservation);
+        final List<ReservationSpecWithRentalSpecsResponse> reservationSpecWithRentalSpecsResponse = mapToReservationSpecWithRentalSpecResponse(rentalSpecs, reservation);
+        final Instant rentalAcceptDateTime = reservation.getAcceptDateTime() == null ? null : reservation.getAcceptDateTime().getInstant();
         return new ReservationWithRentalSpecsResponse(reservation.getId(), reservation.getName(),
-                reservationWithMemberNumber.getMemberNumber(), reservation.getAcceptDateTime(), reservationSpecWithRentalSpecsRespons);
+                reservationWithMemberNumber.getMemberNumber(), rentalAcceptDateTime, reservationSpecWithRentalSpecsResponse);
     }
 
     private static List<ReservationSpecWithRentalSpecsResponse> mapToReservationSpecWithRentalSpecResponse(final List<RentalSpec> rentalSpecs, final Reservation reservation) {

--- a/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.girigiri.kwrental.rental.repository;
 
 import com.girigiri.kwrental.rental.domain.RentalSpec;
+import com.girigiri.kwrental.rental.dto.response.RentalSpecWithName;
 import com.girigiri.kwrental.rental.repository.dto.RentalDto;
 import com.girigiri.kwrental.rental.repository.dto.RentalSpecStatuesPerPropertyNumber;
 
@@ -21,4 +22,6 @@ public interface RentalSpecRepositoryCustom {
     List<RentalDto> findRentalDtosBetweenDate(Long memberId, LocalDate from, LocalDate to);
 
     List<RentalSpecStatuesPerPropertyNumber> findStatusesByPropertyNumbersBetweenDate(Set<String> propertyNumbers, LocalDate from, LocalDate to);
+
+    List<RentalSpecWithName> findTerminatedWithNameByPropertyNumber(String propertyNumber);
 }

--- a/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.girigiri.kwrental.rental.repository;
 
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.girigiri.kwrental.rental.domain.RentalSpecStatus;
+import com.girigiri.kwrental.rental.dto.response.RentalSpecWithName;
 import com.girigiri.kwrental.rental.repository.dto.RentalDto;
 import com.girigiri.kwrental.rental.repository.dto.RentalSpecDto;
 import com.girigiri.kwrental.rental.repository.dto.RentalSpecStatuesPerPropertyNumber;
@@ -91,5 +92,15 @@ public class RentalSpecRepositoryCustomImpl implements RentalSpecRepositoryCusto
         return statusPerPropertyNumber.entrySet().stream()
                 .map(entry -> new RentalSpecStatuesPerPropertyNumber(entry.getKey(), entry.getValue()))
                 .toList();
+    }
+
+    @Override
+    public List<RentalSpecWithName> findTerminatedWithNameByPropertyNumber(final String propertyNumber) {
+        return jpaQueryFactory
+                .select(Projections.constructor(RentalSpecWithName.class, reservation.name, rentalSpec.acceptDateTime, rentalSpec.returnDateTime, rentalSpec.status))
+                .from(rentalSpec)
+                .join(reservation).on(reservation.id.eq(rentalSpec.reservationId), reservation.terminated.isTrue())
+                .where(rentalSpec.propertyNumber.eq(propertyNumber))
+                .fetch();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.girigiri.kwrental.rental.repository;
 
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.girigiri.kwrental.rental.domain.RentalSpecStatus;
 import com.girigiri.kwrental.rental.dto.response.RentalSpecWithName;
@@ -52,8 +53,8 @@ public class RentalSpecRepositoryCustomImpl implements RentalSpecRepositoryCusto
                 jpaQueryFactory.selectFrom(rentalSpec)
                         .leftJoin(reservationSpec).on(rentalSpec.reservationSpecId.eq(reservationSpec.id))
                         .where(reservationSpec.equipment.id.eq(equipmentId)
-                                .and(rentalSpec.acceptDateTime.loe(dateTime))
-                                .and(rentalSpec.returnDateTime.isNull()))
+                                .and(rentalSpec.acceptDateTime.instant.loe(RentalDateTime.from(dateTime).getInstant())
+                                        .and(rentalSpec.returnDateTime.isNull())))
                         .fetch());
     }
 

--- a/src/main/java/com/girigiri/kwrental/rental/service/RentalService.java
+++ b/src/main/java/com/girigiri/kwrental/rental/service/RentalService.java
@@ -8,6 +8,8 @@ import com.girigiri.kwrental.rental.dto.request.CreateRentalRequest;
 import com.girigiri.kwrental.rental.dto.request.RentalSpecsRequest;
 import com.girigiri.kwrental.rental.dto.request.ReturnRentalRequest;
 import com.girigiri.kwrental.rental.dto.request.ReturnRentalSpecRequest;
+import com.girigiri.kwrental.rental.dto.response.RentalSpecWithName;
+import com.girigiri.kwrental.rental.dto.response.RentalSpecsByItemResponse;
 import com.girigiri.kwrental.rental.dto.response.RentalsDto;
 import com.girigiri.kwrental.rental.dto.response.ReservationsWithRentalSpecsByEndDateResponse;
 import com.girigiri.kwrental.rental.dto.response.overduereservations.OverdueReservationsWithRentalSpecsResponse;
@@ -22,10 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toMap;
@@ -157,5 +156,12 @@ public class RentalService {
     @Transactional(readOnly = true)
     public RentalsDto getRentalsBetweenDate(final Long memberId, final LocalDate from, final LocalDate to) {
         return new RentalsDto(rentalSpecRepository.findRentalDtosBetweenDate(memberId, from, to));
+    }
+
+    @Transactional(readOnly = true)
+    public RentalSpecsByItemResponse getReturnedRentalSpecs(final String propertyNumber) {
+        final List<RentalSpecWithName> rentalSpecsWithName = rentalSpecRepository.findTerminatedWithNameByPropertyNumber(propertyNumber);
+        Collections.reverse(rentalSpecsWithName);
+        return RentalSpecsByItemResponse.from(rentalSpecsWithName);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
@@ -1,5 +1,6 @@
 package com.girigiri.kwrental.reservation.domain;
 
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.inventory.domain.RentalPeriod;
 import com.girigiri.kwrental.reservation.exception.ReservationException;
 import jakarta.persistence.*;
@@ -36,7 +37,9 @@ public class Reservation {
     @Column(nullable = false, name = "is_terminated")
     private boolean terminated = false;
 
-    private LocalDateTime acceptDateTime;
+    @Embedded
+    @AttributeOverride(name = "instant", column = @Column(name = "accept_date_time"))
+    private RentalDateTime acceptDateTime;
 
     @Column(nullable = false)
     private Long memberId;
@@ -47,7 +50,7 @@ public class Reservation {
     }
 
     @Builder
-    private Reservation(final Long id, final List<ReservationSpec> reservationSpecs, final String name, final String email, final String phoneNumber, final String purpose, final boolean terminated, final LocalDateTime acceptDateTime, final Long memberId) {
+    private Reservation(final Long id, final List<ReservationSpec> reservationSpecs, final String name, final String email, final String phoneNumber, final String purpose, final boolean terminated, final RentalDateTime acceptDateTime, final Long memberId) {
         this.id = id;
         this.terminated = terminated;
         this.acceptDateTime = acceptDateTime;
@@ -72,7 +75,7 @@ public class Reservation {
     }
 
     public void acceptAt(final LocalDateTime acceptDateTime) {
-        this.acceptDateTime = acceptDateTime;
+        this.acceptDateTime = RentalDateTime.from(acceptDateTime);
     }
 
     public boolean isAccepted() {

--- a/src/test/java/com/girigiri/kwrental/rental/domain/RentalSpecTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/domain/RentalSpecTest.java
@@ -1,5 +1,6 @@
 package com.girigiri.kwrental.rental.domain;
 
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.testsupport.fixture.RentalSpecFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,9 +18,9 @@ class RentalSpecTest {
     @DisplayName("대여 상세가 대여중인지 확인한다.")
     void isNowRental() {
         // given
-        final LocalDateTime now = LocalDateTime.now();
+        final RentalDateTime now = RentalDateTime.now();
         final RentalSpec rentalSpec1 = RentalSpecFixture.builder().acceptDateTime(now).returnDateTime(null).build();
-        final RentalSpec rentalSpec2 = RentalSpecFixture.builder().acceptDateTime(now).returnDateTime(now.plusSeconds(1)).build();
+        final RentalSpec rentalSpec2 = RentalSpecFixture.builder().acceptDateTime(now).returnDateTime(now.calculateDay(1)).build();
 
         // when
         final boolean nowRental = rentalSpec1.isNowRental();

--- a/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
@@ -5,6 +5,7 @@ import com.girigiri.kwrental.auth.repository.MemberRepository;
 import com.girigiri.kwrental.config.JpaConfig;
 import com.girigiri.kwrental.equipment.domain.Equipment;
 import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.inventory.domain.RentalPeriod;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.girigiri.kwrental.rental.domain.RentalSpecStatus;
@@ -69,8 +70,8 @@ class RentalSpecRepositoryTest {
     @DisplayName("특정 기자재의 특정 날짜에 대여 중인 대여 상세를 조회한다.")
     void findRentedRentalSpecs() {
         // given
-        final LocalDateTime acceptTime = LocalDateTime.now();
-        final LocalDateTime returnTime = LocalDateTime.now();
+        final RentalDateTime acceptTime = RentalDateTime.now();
+        final RentalDateTime returnTime = RentalDateTime.now();
         final Equipment equipment1 = equipmentRepository.save(EquipmentFixture.builder().modelName("modelName1").build());
         final Equipment equipment2 = equipmentRepository.save(EquipmentFixture.builder().modelName("modelName2").build());
         final ReservationSpec reservationSpec1 = reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).build());

--- a/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
@@ -185,7 +185,11 @@ class RentalSpecRepositoryTest {
         final List<RentalSpecWithName> result = rentalSpecRepository.findTerminatedWithNameByPropertyNumber(rentalSpec.getPropertyNumber());
 
         // then
-        assertThat(result).usingRecursiveFieldByFieldElementComparator()
-                .containsExactly(new RentalSpecWithName(reservation.getName(), rentalSpec.getAcceptDateTime(), rentalSpec.getReturnDateTime(), rentalSpec.getStatus()));
+        assertAll(
+                () -> assertThat(result).hasSize(1),
+                () -> assertThat(result.get(0)).usingRecursiveComparison()
+                        .isEqualTo(new RentalSpecWithName(
+                                reservation.getName(), rentalSpec.getAcceptDateTime(), rentalSpec.getReturnDateTime(), rentalSpec.getStatus()))
+        );
     }
 }

--- a/src/test/java/com/girigiri/kwrental/rental/service/RentalServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/service/RentalServiceTest.java
@@ -2,6 +2,7 @@ package com.girigiri.kwrental.rental.service;
 
 import com.girigiri.kwrental.equipment.domain.Equipment;
 import com.girigiri.kwrental.inventory.domain.RentalAmount;
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.inventory.domain.RentalPeriod;
 import com.girigiri.kwrental.item.service.ItemService;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
@@ -32,7 +33,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -122,7 +122,7 @@ class RentalServiceTest {
         final Equipment equipment2 = EquipmentFixture.create();
         final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment1).id(1L).build();
         final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment2).id(2L).build();
-        final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).id(1L).acceptDateTime(LocalDateTime.now()).build();
+        final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).id(1L).acceptDateTime(RentalDateTime.now()).build();
         final RentalSpec rentalSpec1 = RentalSpecFixture.builder().reservationSpecId(reservationSpec1.getId()).build();
         final RentalSpec rentalSpec2 = RentalSpecFixture.builder().reservationSpecId(reservationSpec2.getId()).build();
         final ReservationWithMemberNumber reservationWithMemberNumber = new ReservationWithMemberNumber(reservation, "11111111");

--- a/src/test/java/com/girigiri/kwrental/testsupport/fixture/RentalSpecFixture.java
+++ b/src/test/java/com/girigiri/kwrental/testsupport/fixture/RentalSpecFixture.java
@@ -1,9 +1,8 @@
 package com.girigiri.kwrental.testsupport.fixture;
 
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.rental.domain.RentalSpec;
 import com.girigiri.kwrental.rental.domain.RentalSpecStatus;
-
-import java.time.LocalDateTime;
 
 public class RentalSpecFixture {
 
@@ -13,7 +12,7 @@ public class RentalSpecFixture {
 
     public static RentalSpec.RentalSpecBuilder builder() {
         return RentalSpec.builder()
-                .acceptDateTime(LocalDateTime.now())
+                .acceptDateTime(RentalDateTime.now())
                 .propertyNumber("12345678")
                 .reservationSpecId(0L)
                 .reservationId(0L)


### PR DESCRIPTION
특정 품목을 대여하여 사용한 이력을 조회한다.
이때 반납이 완료된 이력만 조회한다. 각 이력은 정상 반납과 불량 반납으로 구분된다. 사유에는 해당 반납 상태에 따른 사유가 포함된다. (파손, 분실, 연체 반납)