### PR TITLE
특정 기자재의 날짜별 남은 갯수 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/equipment.adoc
+++ b/src/docs/asciidoc/equipment.adoc
@@ -37,3 +37,7 @@ operation::admin_uploadImage[snippets='http-request,http-response']
 ==== Location 헤더에 수정된 기자재 정보로 접근할 수 있다.
 
 operation::admin_updateEquipment[snippets='http-request,http-response']
+
+=== 기자재 날짜 별 대여 가능 갯수 조회 API
+
+operation::admin_getEquipmentRemainQuantities[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/equipment/controller/AdminEquipmentController.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/controller/AdminEquipmentController.java
@@ -6,6 +6,7 @@ import com.girigiri.kwrental.equipment.dto.request.EquipmentSearchCondition;
 import com.girigiri.kwrental.equipment.dto.request.UpdateEquipmentRequest;
 import com.girigiri.kwrental.equipment.dto.response.EquipmentDetailResponse;
 import com.girigiri.kwrental.equipment.dto.response.EquipmentPageResponse;
+import com.girigiri.kwrental.equipment.dto.response.RemainQuantitiesPerDateResponse;
 import com.girigiri.kwrental.equipment.dto.response.SimpleEquipmentResponse;
 import com.girigiri.kwrental.equipment.exception.EquipmentException;
 import com.girigiri.kwrental.equipment.service.EquipmentService;
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -90,5 +92,10 @@ public class AdminEquipmentController {
         return ResponseEntity.noContent()
                 .location(URI.create("/api/equipments/" + updatedResponse.id()))
                 .build();
+    }
+
+    @GetMapping("/{id}/remainQuantities")
+    public RemainQuantitiesPerDateResponse getRemainQuantitiesBetween(@PathVariable final Long id, final LocalDate from, final LocalDate to) {
+        return equipmentService.getRemainQuantitiesPerDate(id, from, to);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/equipment/dto/response/RemainQuantitiesPerDateResponse.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/dto/response/RemainQuantitiesPerDateResponse.java
@@ -1,0 +1,17 @@
+package com.girigiri.kwrental.equipment.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RemainQuantitiesPerDateResponse {
+    private List<RemainQuantityPerDateResponse> remainQuantities;
+
+    private RemainQuantitiesPerDateResponse() {
+    }
+
+    public RemainQuantitiesPerDateResponse(final List<RemainQuantityPerDateResponse> remainQuantities) {
+        this.remainQuantities = remainQuantities;
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/equipment/dto/response/RemainQuantityPerDateResponse.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/dto/response/RemainQuantityPerDateResponse.java
@@ -1,0 +1,19 @@
+package com.girigiri.kwrental.equipment.dto.response;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class RemainQuantityPerDateResponse {
+    private LocalDate date;
+    private Integer remainQuantity;
+
+    private RemainQuantityPerDateResponse() {
+    }
+
+    public RemainQuantityPerDateResponse(final LocalDate date, final Integer remainQuantity) {
+        this.date = date;
+        this.remainQuantity = remainQuantity;
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/equipment/service/RemainingQuantityService.java
+++ b/src/main/java/com/girigiri/kwrental/equipment/service/RemainingQuantityService.java
@@ -7,4 +7,6 @@ import java.util.Map;
 public interface RemainingQuantityService {
 
     Map<Long, Integer> getRemainingQuantityByEquipmentIdAndDate(List<Long> equipmentIds, LocalDate date);
+
+    Map<LocalDate, Integer> getReservedAmountBetween(Long equipmentId, LocalDate from, LocalDate to);
 }

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
@@ -6,11 +6,8 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.HashSet;
-import java.util.Set;
 
 @Embeddable
 @Getter
@@ -53,20 +50,6 @@ public class RentalPeriod implements Comparable<RentalPeriod> {
 
     public boolean isLegalReturnIn(final LocalDate date) {
         return this.contains(date) || rentalEndDate.isEqual(date);
-    }
-
-    public Set<LocalDate> getRentalAvailableDates() {
-        final Set<LocalDate> availableDates = new HashSet<>();
-        for (LocalDate i = rentalStartDate; i.isBefore(rentalEndDate) || i.equals(rentalEndDate); i = i.plusDays(1)) {
-            if (isRentalAvailable(i)) availableDates.add(i);
-        }
-        return availableDates;
-    }
-
-    private boolean isRentalAvailable(final LocalDate date) {
-        final DayOfWeek dayOfWeek = date.getDayOfWeek();
-        return dayOfWeek.equals(DayOfWeek.MONDAY) || dayOfWeek.equals(DayOfWeek.TUESDAY)
-                || dayOfWeek.equals(DayOfWeek.WEDNESDAY) || dayOfWeek.equals(DayOfWeek.THURSDAY);
     }
 
     @Override

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
@@ -6,8 +6,11 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.Set;
 
 @Embeddable
 @Getter
@@ -50,6 +53,20 @@ public class RentalPeriod implements Comparable<RentalPeriod> {
 
     public boolean isLegalReturnIn(final LocalDate date) {
         return this.contains(date) || rentalEndDate.isEqual(date);
+    }
+
+    public Set<LocalDate> getRentalAvailableDates() {
+        final Set<LocalDate> availableDates = new HashSet<>();
+        for (LocalDate i = rentalStartDate; i.isBefore(rentalEndDate) || i.equals(rentalEndDate); i = i.plusDays(1)) {
+            if (isRentalAvailable(i)) availableDates.add(i);
+        }
+        return availableDates;
+    }
+
+    private boolean isRentalAvailable(final LocalDate date) {
+        final DayOfWeek dayOfWeek = date.getDayOfWeek();
+        return dayOfWeek.equals(DayOfWeek.MONDAY) || dayOfWeek.equals(DayOfWeek.TUESDAY)
+                || dayOfWeek.equals(DayOfWeek.WEDNESDAY) || dayOfWeek.equals(DayOfWeek.THURSDAY);
     }
 
     @Override

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/OperatingPeriod.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/OperatingPeriod.java
@@ -1,0 +1,33 @@
+package com.girigiri.kwrental.reservation.domain;
+
+import lombok.Getter;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+public class OperatingPeriod {
+    private final LocalDate start;
+    private final LocalDate end;
+
+    public OperatingPeriod(final LocalDate start, final LocalDate end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public Set<LocalDate> getRentalAvailableDates() {
+        final Set<LocalDate> availableDates = new HashSet<>();
+        for (LocalDate i = start; i.isBefore(end) || i.equals(end); i = i.plusDays(1)) {
+            if (isRentalAvailable(i)) availableDates.add(i);
+        }
+        return availableDates;
+    }
+
+    private boolean isRentalAvailable(final LocalDate date) {
+        final DayOfWeek dayOfWeek = date.getDayOfWeek();
+        return dayOfWeek.equals(DayOfWeek.MONDAY) || dayOfWeek.equals(DayOfWeek.TUESDAY)
+                || dayOfWeek.equals(DayOfWeek.WEDNESDAY) || dayOfWeek.equals(DayOfWeek.THURSDAY);
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustom.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface ReservationSpecRepositoryCustom {
     List<ReservationSpec> findOverlappedByPeriod(Long equipmentId, RentalPeriod rentalPeriod);
 
+    List<ReservationSpec> findOverlappedBetween(Long equipmentId, LocalDate start, LocalDate end);
+
     List<ReservedAmount> findRentalAmountsByEquipmentIds(List<Long> equipmentIds, LocalDate date);
 
     List<ReservationSpec> findByStartDateBetween(Long equipmentId, LocalDate start, LocalDate end);

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustomImpl.java
@@ -40,6 +40,11 @@ public class ReservationSpecRepositoryCustomImpl implements ReservationSpecRepos
     }
 
     @Override
+    public List<ReservationSpec> findOverlappedBetween(final Long equipmentId, final LocalDate start, final LocalDate end) {
+        return findOverlappedByPeriod(equipmentId, new RentalPeriod(start, end.plusDays(1)));
+    }
+
+    @Override
     public List<ReservedAmount> findRentalAmountsByEquipmentIds(final List<Long> equipmentIds, final LocalDate date) {
         return queryFactory
                 .select(

--- a/src/main/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImpl.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImpl.java
@@ -6,6 +6,7 @@ import com.girigiri.kwrental.equipment.repository.EquipmentRepository;
 import com.girigiri.kwrental.equipment.service.RemainingQuantityService;
 import com.girigiri.kwrental.inventory.domain.RentalPeriod;
 import com.girigiri.kwrental.inventory.service.AmountValidator;
+import com.girigiri.kwrental.reservation.domain.OperatingPeriod;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.exception.NotEnoughAmountException;
 import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
@@ -68,9 +69,9 @@ public class RemainingQuantityServiceImpl implements RemainingQuantityService, A
     @Override
     @Transactional(readOnly = true, propagation = Propagation.MANDATORY)
     public Map<LocalDate, Integer> getReservedAmountBetween(final Long equipmentId, final LocalDate from, final LocalDate to) {
-        final RentalPeriod rentalPeriod = new RentalPeriod(from, to);
-        final List<ReservationSpec> overlappedByPeriod = reservationSpecRepository.findOverlappedByPeriod(equipmentId, rentalPeriod);
-        return rentalPeriod.getRentalAvailableDates().stream()
+        final List<ReservationSpec> overlappedByPeriod = reservationSpecRepository.findOverlappedBetween(equipmentId, from, to);
+        final OperatingPeriod operatingPeriod = new OperatingPeriod(from, to);
+        return operatingPeriod.getRentalAvailableDates().stream()
                 .collect(toMap(Function.identity(), date -> getReservedAmountsByDate(overlappedByPeriod, date)));
     }
 

--- a/src/main/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImpl.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImpl.java
@@ -65,6 +65,7 @@ public class RemainingQuantityServiceImpl implements RemainingQuantityService, A
                 .sum();
     }
 
+    @Override
     @Transactional(readOnly = true, propagation = Propagation.MANDATORY)
     public Map<LocalDate, Integer> getReservedAmountBetween(final Long equipmentId, final LocalDate from, final LocalDate to) {
         final RentalPeriod rentalPeriod = new RentalPeriod(from, to);

--- a/src/test/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImplTest.java
@@ -9,6 +9,7 @@ import com.girigiri.kwrental.reservation.exception.NotEnoughAmountException;
 import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
 import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
 import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
@@ -71,5 +73,33 @@ class RemainingQuantityServiceImplTest {
         // when, then
         assertThatThrownBy(() -> remainingQuantityService.validateAmount(1L, 1, new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))))
                 .isExactlyInstanceOf(NotEnoughAmountException.class);
+    }
+
+    @Test
+    @DisplayName("")
+    void getReservedAmountBetween() {
+        // given
+        final Equipment equipment = EquipmentFixture.builder().id(1L).totalQuantity(2).build();
+        final LocalDate monday = LocalDate.of(2023, 5, 15);
+        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+                .period(new RentalPeriod(monday, monday.plusDays(1))).build();
+        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+                .period(new RentalPeriod(monday.plusDays(1), monday.plusDays(2))).build();
+        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+                .period(new RentalPeriod(monday.plusDays(2), monday.plusDays(3))).build();
+        final ReservationSpec reservationSpec4 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+                .period(new RentalPeriod(monday.plusDays(3), monday.plusDays(4))).build();
+        given(reservationSpecRepository.findOverlappedByPeriod(any(), any()))
+                .willReturn(List.of(reservationSpec1, reservationSpec2, reservationSpec3, reservationSpec4));
+
+        // when
+        final Map<LocalDate, Integer> reservedAmount = remainingQuantityService.getReservedAmountBetween(equipment.getId(), monday, monday.plusDays(4));
+
+        // then
+        Assertions.assertThat(reservedAmount)
+                .containsEntry(monday, 1)
+                .containsEntry(monday.plusDays(1), 1)
+                .containsEntry(monday.plusDays(2), 1)
+                .containsEntry(monday.plusDays(3), 1);
     }
 }

--- a/src/test/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImplTest.java
@@ -89,7 +89,7 @@ class RemainingQuantityServiceImplTest {
                 .period(new RentalPeriod(monday.plusDays(2), monday.plusDays(3))).build();
         final ReservationSpec reservationSpec4 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
                 .period(new RentalPeriod(monday.plusDays(3), monday.plusDays(4))).build();
-        given(reservationSpecRepository.findOverlappedByPeriod(any(), any()))
+        given(reservationSpecRepository.findOverlappedBetween(any(), any(), any()))
                 .willReturn(List.of(reservationSpec1, reservationSpec2, reservationSpec3, reservationSpec4));
 
         // when


### PR DESCRIPTION
특정 날짜 별 남은 갯수를 조회한다. 이때 특정 날짜는 구간으로 주어지는데, 운영 날짜에만 조회되도록 구현했다.