### PR TITLE
대여 예약 상세를 취소 API

### DIFF
--- a/src/docs/asciidoc/reservation.adoc
+++ b/src/docs/asciidoc/reservation.adoc
@@ -20,3 +20,7 @@ operation::admin_getReservationByEquipment[snippets='http-request,http-response'
 - `CANCELED` : 대여 취소
 
 operation::getUnterminatedReservations[snippets='http-request,http-response']
+
+=== 대여 취소하기
+
+operation::admin_cancelReservationSpec[snippets='http-request,http-response']

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/RentalAmount.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/RentalAmount.java
@@ -17,10 +17,28 @@ public class RentalAmount {
     protected RentalAmount() {
     }
 
-    public RentalAmount(final Integer amount) {
-        if (amount == null || amount <= 0) {
-            throw new RentalAmountException("대여 갯수는 양수어야 합니다.");
+    private RentalAmount(final Integer amount) {
+        if (amount == null || amount < 0) {
+            throw new RentalAmountException("대여 갯수는 음수 일 수 없습니다.");
         }
         this.amount = amount;
+    }
+
+    public static RentalAmount ofPositive(final Integer amount) {
+        if (amount == null || amount <= 0) {
+            throw new RentalAmountException("대여 갯수는 양수여야 합니다.");
+        }
+        return new RentalAmount(amount);
+    }
+
+    public RentalAmount subtract(final RentalAmount right) {
+        if (this.amount < right.amount) {
+            throw new RentalAmountException("대여 갯수가 음수가 될 수 없습니다.");
+        }
+        return new RentalAmount(this.amount - right.amount);
+    }
+
+    public boolean isZero() {
+        return this.amount == 0;
     }
 }

--- a/src/main/java/com/girigiri/kwrental/inventory/service/InventoryService.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/service/InventoryService.java
@@ -47,7 +47,7 @@ public class InventoryService {
         final Inventory inventory = foundInventory.get();
         final int updatedAmount = inventory.getRentalAmount().getAmount() + addInventoryRequest.getAmount();
         amountValidator.validateAmount(equipmentId, updatedAmount, inventory.getRentalPeriod());
-        inventoryRepository.updateAmount(inventory.getId(), new RentalAmount(updatedAmount));
+        inventoryRepository.updateAmount(inventory.getId(), RentalAmount.ofPositive(updatedAmount));
         return inventory.getId();
     }
 
@@ -56,7 +56,7 @@ public class InventoryService {
         return Inventory.builder()
                 .equipment(equipment)
                 .rentalPeriod(rentalPeriod)
-                .rentalAmount(new RentalAmount(addInventoryRequest.getAmount()))
+                .rentalAmount(RentalAmount.ofPositive(addInventoryRequest.getAmount()))
                 .memberId(memberId)
                 .build();
     }
@@ -93,7 +93,7 @@ public class InventoryService {
         validateInventoryMemberId(memberId, inventory);
         amountValidator.validateAmount(inventory.getEquipment().getId(), request.getAmount(),
                 new RentalPeriod(request.getRentalStartDate(), request.getRentalEndDate()));
-        inventory.setRentalAmount(new RentalAmount(request.getAmount()));
+        inventory.setRentalAmount(RentalAmount.ofPositive(request.getAmount()));
         inventory.setRentalPeriod(new RentalPeriod(request.getRentalStartDate(), request.getRentalEndDate()));
         return InventoryResponse.from(inventory);
     }

--- a/src/main/java/com/girigiri/kwrental/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/controller/AdminReservationController.java
@@ -1,11 +1,13 @@
 package com.girigiri.kwrental.reservation.controller;
 
+import com.girigiri.kwrental.reservation.dto.request.CancelReservationSpecRequest;
 import com.girigiri.kwrental.reservation.dto.response.ReservationsByEquipmentPerYearMonthResponse;
 import com.girigiri.kwrental.reservation.service.ReservationService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.time.YearMonth;
 
 @RestController
@@ -21,5 +23,13 @@ public class AdminReservationController {
     @GetMapping
     public ReservationsByEquipmentPerYearMonthResponse getReservationsByEquipmentPerYearMonth(final Long equipmentId, final YearMonth yearMonth) {
         return reservationService.getReservationsByEquipmentsPerYearMonth(equipmentId, yearMonth);
+    }
+
+    @PatchMapping("/specs/{reservationSpecId}")
+    public ResponseEntity<?> cancelReservationSpec(@PathVariable Long reservationSpecId,
+                                                   @Validated @RequestBody final CancelReservationSpecRequest body) {
+        final Long cancelReservationSpecId = reservationService.cancelReservationSpec(reservationSpecId, body.getAmount());
+        return ResponseEntity.noContent()
+                .location(URI.create("/api/reservations/specs/" + cancelReservationSpecId)).build();
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
@@ -84,12 +84,7 @@ public class Reservation {
 
     public void updateIfTerminated() {
         this.terminated = reservationSpecs.stream()
-                .map(ReservationSpec::getStatus)
-                .allMatch(it ->
-                        it != ReservationSpecStatus.RESERVED
-                                && it != ReservationSpecStatus.RENTED
-                                && it != ReservationSpecStatus.OVERDUE_RENTED
-                );
+                .allMatch(ReservationSpec::isTerminated);
     }
 
     public RentalPeriod getRentalPeriod() {

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/Reservation.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -56,7 +57,7 @@ public class Reservation {
         this.acceptDateTime = acceptDateTime;
         this.memberId = memberId;
         validateReservationSpec(reservationSpecs);
-        this.reservationSpecs = reservationSpecs;
+        this.reservationSpecs = new ArrayList<>(reservationSpecs);
         reservationSpecs.forEach(it -> it.setReservation(this));
         this.name = name;
         this.email = email;

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/ReservationSpec.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/ReservationSpec.java
@@ -91,4 +91,10 @@ public class ReservationSpec {
             this.status = ReservationSpecStatus.CANCELED;
         }
     }
+
+    public boolean isTerminated() {
+        return status != ReservationSpecStatus.RESERVED
+                && status != ReservationSpecStatus.RENTED
+                && status != ReservationSpecStatus.OVERDUE_RENTED;
+    }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/domain/ReservationSpec.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/domain/ReservationSpec.java
@@ -66,7 +66,8 @@ public class ReservationSpec {
     }
 
     public void validateAmount(final int amount) {
-        if (this.amount.getAmount() != amount) throw new ReservationSpecException("대여 신청 갯수가 맞지 않습니다.");
+        if (!this.amount.equals(RentalAmount.ofPositive(amount)))
+            throw new ReservationSpecException("대여 신청 갯수가 맞지 않습니다.");
     }
 
     public boolean isLegalReturnIn(final LocalDate date) {
@@ -79,5 +80,15 @@ public class ReservationSpec {
 
     public LocalDate getEndDate() {
         return this.period.getRentalEndDate();
+    }
+
+    public void cancelAmount(final Integer amount) {
+        if (this.status != ReservationSpecStatus.RESERVED) {
+            throw new ReservationSpecException("대여 예약 상세 취소는 예약 상태에서만 가능합니다.");
+        }
+        this.amount = this.amount.subtract(RentalAmount.ofPositive(amount));
+        if (this.amount.isZero()) {
+            this.status = ReservationSpecStatus.CANCELED;
+        }
     }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/dto/request/CancelReservationSpecRequest.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/dto/request/CancelReservationSpecRequest.java
@@ -1,0 +1,19 @@
+package com.girigiri.kwrental.reservation.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CancelReservationSpecRequest {
+    @NotNull
+    @Min(1L)
+    private Integer amount;
+
+    private CancelReservationSpecRequest() {
+    }
+
+    public CancelReservationSpecRequest(final Integer amount) {
+        this.amount = amount;
+    }
+}

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationRepositoryCustom.java
@@ -18,4 +18,6 @@ public interface ReservationRepositoryCustom {
     Set<ReservationWithMemberNumber> findReservationsWithSpecsByEndDate(LocalDate localDate);
 
     Set<Reservation> findNotTerminatedReservationsByMemberId(Long memberId);
+
+    void adjustTerminated(Reservation reservation);
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepository.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepository.java
@@ -3,7 +3,11 @@ package com.girigiri.kwrental.reservation.repository;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
 public interface ReservationSpecRepository extends Repository<ReservationSpec, Long>, ReservationSpecRepositoryCustom {
 
     ReservationSpec save(ReservationSpec reservationSpec);
+
+    Optional<ReservationSpec> findById(Long id);
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustom.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface ReservationSpecRepositoryCustom {
     List<ReservedAmount> findRentalAmountsByEquipmentIds(List<Long> equipmentIds, LocalDate date);
 
     List<ReservationSpec> findByStartDateBetween(Long equipmentId, LocalDate start, LocalDate end);
+
+    void adjustAmountAndStatus(ReservationSpec reservationSpec);
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/service/ReservationService.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/service/ReservationService.java
@@ -31,14 +31,17 @@ public class ReservationService {
     private final InventoryService inventoryService;
     private final RemainingQuantityServiceImpl remainingQuantityService;
     private final ReservationSpecRepositoryCustom rentalSpecRepository;
+    private final ReservationSpecRepositoryCustom reservationSpecRepository;
 
     public ReservationService(final ReservationRepository reservationRepository, final InventoryService inventoryService,
                               final RemainingQuantityServiceImpl remainingQuantityService,
-                              final ReservationSpecRepository rentalSpecRepository) {
+                              final ReservationSpecRepository rentalSpecRepository,
+                              final ReservationSpecRepositoryCustom reservationSpecRepository) {
         this.reservationRepository = reservationRepository;
         this.inventoryService = inventoryService;
         this.remainingQuantityService = remainingQuantityService;
         this.rentalSpecRepository = rentalSpecRepository;
+        this.reservationSpecRepository = reservationSpecRepository;
     }
 
     @Transactional
@@ -142,4 +145,12 @@ public class ReservationService {
         reservationList.sort(Comparator.comparing(Reservation::getRentalPeriod));
         return UnterminatedReservationsResponse.from(reservationList);
     }
+
+//    @Transactional
+//    public Long cancelReservationSpec(final Long reservationSpecId, final Integer amount) {
+//        final ReservationSpec reservationSpec = reservationSpecRepository.findById(reservationSpecId)
+//                .orElseThrow(ReservationSpecNotFoundException::new);
+//        reservationSpec.cancelAmount(amount);
+//        reservationSpecRepository.adjustAmountAndStatus(reservationSpec);
+//    }
 }

--- a/src/main/java/com/girigiri/kwrental/reservation/service/ReservationService.java
+++ b/src/main/java/com/girigiri/kwrental/reservation/service/ReservationService.java
@@ -10,9 +10,9 @@ import com.girigiri.kwrental.reservation.dto.response.ReservationsByEquipmentPer
 import com.girigiri.kwrental.reservation.dto.response.UnterminatedReservationsResponse;
 import com.girigiri.kwrental.reservation.exception.ReservationNotFoundException;
 import com.girigiri.kwrental.reservation.exception.ReservationSpecException;
+import com.girigiri.kwrental.reservation.exception.ReservationSpecNotFoundException;
 import com.girigiri.kwrental.reservation.repository.ReservationRepository;
 import com.girigiri.kwrental.reservation.repository.ReservationSpecRepository;
-import com.girigiri.kwrental.reservation.repository.ReservationSpecRepositoryCustom;
 import com.girigiri.kwrental.reservation.repository.dto.ReservationWithMemberNumber;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -30,17 +30,14 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final InventoryService inventoryService;
     private final RemainingQuantityServiceImpl remainingQuantityService;
-    private final ReservationSpecRepositoryCustom rentalSpecRepository;
-    private final ReservationSpecRepositoryCustom reservationSpecRepository;
+    private final ReservationSpecRepository reservationSpecRepository;
 
     public ReservationService(final ReservationRepository reservationRepository, final InventoryService inventoryService,
                               final RemainingQuantityServiceImpl remainingQuantityService,
-                              final ReservationSpecRepository rentalSpecRepository,
-                              final ReservationSpecRepositoryCustom reservationSpecRepository) {
+                              final ReservationSpecRepository reservationSpecRepository) {
         this.reservationRepository = reservationRepository;
         this.inventoryService = inventoryService;
         this.remainingQuantityService = remainingQuantityService;
-        this.rentalSpecRepository = rentalSpecRepository;
         this.reservationSpecRepository = reservationSpecRepository;
     }
 
@@ -82,7 +79,7 @@ public class ReservationService {
     public ReservationsByEquipmentPerYearMonthResponse getReservationsByEquipmentsPerYearMonth(final Long equipmentId, final YearMonth yearMonth) {
         LocalDate startOfMonth = yearMonth.atDay(1);
         LocalDate endOfMonth = yearMonth.atEndOfMonth();
-        final List<ReservationSpec> reservationSpecs = rentalSpecRepository.findByStartDateBetween(equipmentId, startOfMonth, endOfMonth);
+        final List<ReservationSpec> reservationSpecs = reservationSpecRepository.findByStartDateBetween(equipmentId, startOfMonth, endOfMonth);
         final ReservationCalendar calendar = ReservationCalendar.from(startOfMonth, endOfMonth);
         calendar.addAll(reservationSpecs);
         return ReservationsByEquipmentPerYearMonthResponse.from(calendar);
@@ -146,11 +143,25 @@ public class ReservationService {
         return UnterminatedReservationsResponse.from(reservationList);
     }
 
-//    @Transactional
-//    public Long cancelReservationSpec(final Long reservationSpecId, final Integer amount) {
-//        final ReservationSpec reservationSpec = reservationSpecRepository.findById(reservationSpecId)
-//                .orElseThrow(ReservationSpecNotFoundException::new);
-//        reservationSpec.cancelAmount(amount);
-//        reservationSpecRepository.adjustAmountAndStatus(reservationSpec);
-//    }
+    @Transactional
+    public Long cancelReservationSpec(final Long reservationSpecId, final Integer amount) {
+        final ReservationSpec reservationSpec = getReservationSpec(reservationSpecId);
+        reservationSpec.cancelAmount(amount);
+        reservationSpecRepository.adjustAmountAndStatus(reservationSpec);
+        final Long reservationId = reservationSpec.getReservation().getId();
+        updateAndAdjustTerminated(reservationId);
+        return reservationSpec.getId();
+    }
+
+    private ReservationSpec getReservationSpec(final Long reservationSpecId) {
+        return reservationSpecRepository.findById(reservationSpecId)
+                .orElseThrow(ReservationSpecNotFoundException::new);
+    }
+
+    private void updateAndAdjustTerminated(final Long reservationId) {
+        final Reservation reservation = reservationRepository.findByIdWithSpecs(reservationId)
+                .orElseThrow(ReservationNotFoundException::new);
+        reservation.updateIfTerminated();
+        if (reservation.isTerminated()) reservationRepository.adjustTerminated(reservation);
+    }
 }

--- a/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/EquipmentAcceptanceTest.java
@@ -174,9 +174,9 @@ class EquipmentAcceptanceTest extends AcceptanceTest {
         final Equipment equipment2 = EquipmentFixture.builder().modelName("equipment2").totalQuantity(10).build();
         equipmentRepository.save(equipment2);
         LocalDate date = LocalDate.of(2023, 1, 1);
-        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(5)).period(new RentalPeriod(date, date.plusDays(1))).build());
-        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(2)).period(new RentalPeriod(date, date.plusDays(1))).build());
-        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment2).amount(new RentalAmount(5)).period(new RentalPeriod(date, date.plusDays(1))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(RentalAmount.ofPositive(5)).period(new RentalPeriod(date, date.plusDays(1))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(RentalAmount.ofPositive(2)).period(new RentalPeriod(date, date.plusDays(1))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment2).amount(RentalAmount.ofPositive(5)).period(new RentalPeriod(date, date.plusDays(1))).build());
 
         // when
         final EquipmentsWithRentalQuantityPageResponse response = RestAssured.given(this.requestSpec)
@@ -315,9 +315,9 @@ class EquipmentAcceptanceTest extends AcceptanceTest {
         final Equipment equipment1 = EquipmentFixture.builder().modelName("equipment1").totalQuantity(10).build();
         equipmentRepository.save(equipment1);
         LocalDate monday = LocalDate.of(2023, 5, 15);
-        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(5)).period(new RentalPeriod(monday, monday.plusDays(1))).build());
-        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(4)).period(new RentalPeriod(monday.plusDays(1), monday.plusDays(2))).build());
-        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(new RentalAmount(3)).period(new RentalPeriod(monday.plusDays(2), monday.plusDays(3))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(RentalAmount.ofPositive(5)).period(new RentalPeriod(monday, monday.plusDays(1))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(RentalAmount.ofPositive(4)).period(new RentalPeriod(monday.plusDays(1), monday.plusDays(2))).build());
+        reservationSpecRepository.save(ReservationSpecFixture.builder(equipment1).amount(RentalAmount.ofPositive(3)).period(new RentalPeriod(monday.plusDays(2), monday.plusDays(3))).build());
 
         // when
         final RemainQuantitiesPerDateResponse response = RestAssured.given(requestSpec)

--- a/src/test/java/com/girigiri/kwrental/inventory/domain/RentalAmountTest.java
+++ b/src/test/java/com/girigiri/kwrental/inventory/domain/RentalAmountTest.java
@@ -4,6 +4,7 @@ import com.girigiri.kwrental.inventory.exception.RentalAmountException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class RentalAmountTest {
@@ -15,7 +16,31 @@ class RentalAmountTest {
         Integer zero = 0;
 
         // when, then
-        assertThatThrownBy(() -> new RentalAmount(zero))
+        assertThatThrownBy(() -> RentalAmount.ofPositive(zero))
+                .isExactlyInstanceOf(RentalAmountException.class);
+    }
+
+    @Test
+    @DisplayName("대여 갯수를 뺀다.")
+    void subtract() {
+        // given
+        final RentalAmount rentalAmount = RentalAmount.ofPositive(10);
+
+        // when
+        final RentalAmount actual = rentalAmount.subtract(RentalAmount.ofPositive(5));
+
+        // then
+        assertThat(actual).isEqualTo(RentalAmount.ofPositive(5));
+    }
+
+    @Test
+    @DisplayName("대여 갯수를 밸 때 결과가 음수면 예외 발생")
+    void subtract_exceptionNegativeResult() {
+        // given
+        final RentalAmount rentalAmount = RentalAmount.ofPositive(10);
+
+        // when, then
+        assertThatThrownBy(() -> rentalAmount.subtract(RentalAmount.ofPositive(11)))
                 .isExactlyInstanceOf(RentalAmountException.class);
     }
 }

--- a/src/test/java/com/girigiri/kwrental/inventory/repository/InventoryRepositoryCustomImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/inventory/repository/InventoryRepositoryCustomImplTest.java
@@ -69,7 +69,7 @@ class InventoryRepositoryCustomImplTest {
         final Inventory inventory = inventoryRepository.save(InventoryFixture.create(equipment, 0L));
 
         // when, then
-        assertThatCode(() -> inventoryRepository.updateAmount(inventory.getId(), new RentalAmount(10)))
+        assertThatCode(() -> inventoryRepository.updateAmount(inventory.getId(), RentalAmount.ofPositive(10)))
                 .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/girigiri/kwrental/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/inventory/service/InventoryServiceTest.java
@@ -83,7 +83,7 @@ class InventoryServiceTest {
         final int updateAmount = inventory.getRentalAmount().getAmount() + 1;
         doNothing().when(amountValidator).validateAmount(
                 eq(1L), eq(updateAmount), eq(inventory.getRentalPeriod()));
-        doNothing().when(inventoryRepository).updateAmount(inventory.getId(), new RentalAmount(updateAmount));
+        doNothing().when(inventoryRepository).updateAmount(inventory.getId(), RentalAmount.ofPositive(updateAmount));
         final AddInventoryRequest addInventoryRequest = AddInventoryRequest.builder()
                 .equipmentId(1L)
                 .amount(1)

--- a/src/test/java/com/girigiri/kwrental/rental/service/RentalServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/service/RentalServiceTest.java
@@ -141,9 +141,9 @@ class RentalServiceTest {
     void returnRental() {
         // given
         final long reservationId = 1L;
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(new RentalAmount(1)).id(1L).build();
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(new RentalAmount(2)).id(2L).build();
-        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(new RentalAmount(1)).id(3L).build();
+        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(RentalAmount.ofPositive(1)).id(1L).build();
+        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(RentalAmount.ofPositive(2)).id(2L).build();
+        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(RentalAmount.ofPositive(1)).id(3L).build();
         final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2, reservationSpec3)).id(reservationId).build();
         given(reservationService.getReservationWithReservationSpecsById(reservationId)).willReturn(reservation);
 
@@ -194,11 +194,11 @@ class RentalServiceTest {
         final long reservationId = 1L;
         final RentalPeriod overduePeriod = new RentalPeriod(LocalDate.now().minusDays(2), LocalDate.now().minusDays(1));
         final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null).status(ReservationSpecStatus.RETURNED)
-                .period(overduePeriod).amount(new RentalAmount(1)).id(1L).build();
+                .period(overduePeriod).amount(RentalAmount.ofPositive(1)).id(1L).build();
         final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null).status(ReservationSpecStatus.OVERDUE_RENTED)
-                .period(overduePeriod).amount(new RentalAmount(2)).id(2L).build();
+                .period(overduePeriod).amount(RentalAmount.ofPositive(2)).id(2L).build();
         final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(null).status(ReservationSpecStatus.ABNORMAL_RETURNED)
-                .period(overduePeriod).amount(new RentalAmount(1)).id(3L).build();
+                .period(overduePeriod).amount(RentalAmount.ofPositive(1)).id(3L).build();
         final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2, reservationSpec3)).id(reservationId).build();
         given(reservationService.getReservationWithReservationSpecsById(reservationId)).willReturn(reservation);
 

--- a/src/test/java/com/girigiri/kwrental/reservation/domain/ReservationSpecTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/domain/ReservationSpecTest.java
@@ -1,0 +1,63 @@
+package com.girigiri.kwrental.reservation.domain;
+
+import com.girigiri.kwrental.inventory.domain.RentalAmount;
+import com.girigiri.kwrental.reservation.exception.ReservationSpecException;
+import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class ReservationSpecTest {
+
+    @Test
+    @DisplayName("대여 예약 상세 일부를 취소한다.")
+    void cancelAmount() {
+        // given
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(null)
+                .status(ReservationSpecStatus.RESERVED)
+                .amount(RentalAmount.ofPositive(2)).build();
+
+        // when
+        reservationSpec.cancelAmount(1);
+
+        // then
+        assertAll(
+                () -> assertThat(reservationSpec.getAmount()).isEqualTo(RentalAmount.ofPositive(1)),
+                () -> assertThat(reservationSpec.getStatus()).isEqualTo(ReservationSpecStatus.RESERVED)
+        );
+    }
+
+    @Test
+    @DisplayName("대여 예약 상세 전부를 취소할 경우 취소 상태로 변한다.")
+    void cancelAmount_allCanceled() {
+        // given
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(null)
+                .status(ReservationSpecStatus.RESERVED)
+                .amount(RentalAmount.ofPositive(2)).build();
+
+        // when
+        reservationSpec.cancelAmount(2);
+
+        // then
+        assertAll(
+                () -> assertThat(reservationSpec.getAmount().getAmount()).isEqualTo(0),
+                () -> assertThat(reservationSpec.getStatus()).isEqualTo(ReservationSpecStatus.CANCELED)
+        );
+    }
+
+    @Test
+    @DisplayName("대여 예약 상세가 예약 상태가 아닐 때 예약을 취소하려면 예외")
+    void cancelAmount_notReserved() {
+        // given
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(null)
+                .status(ReservationSpecStatus.RENTED)
+                .amount(RentalAmount.ofPositive(2)).build();
+
+        // when, then
+        assertThatThrownBy(() -> reservationSpec.cancelAmount(1))
+                .isExactlyInstanceOf(ReservationSpecException.class);
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/reservation/domain/ReservationSpecTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/domain/ReservationSpecTest.java
@@ -5,6 +5,8 @@ import com.girigiri.kwrental.reservation.exception.ReservationSpecException;
 import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,5 +61,19 @@ class ReservationSpecTest {
         // when, then
         assertThatThrownBy(() -> reservationSpec.cancelAmount(1))
                 .isExactlyInstanceOf(ReservationSpecException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"RESERVED,false", "RENTED,false", "RETURNED,true", "ABNORMAL_RETURNED,true", "OVERDUE_RENTED,false", "CANCELED,true"})
+    @DisplayName("대여 예약 상세가 종결됐는 지 판단한다.")
+    void isTerminated(final ReservationSpecStatus status, final boolean expect) {
+        // given
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(null).status(status).build();
+
+        // when
+        final boolean actual = reservationSpec.isTerminated();
+
+        // then
+        assertThat(actual).isEqualTo(expect);
     }
 }

--- a/src/test/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustomImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/repository/ReservationSpecRepositoryCustomImplTest.java
@@ -70,9 +70,9 @@ class ReservationSpecRepositoryCustomImplTest {
         final Equipment equipment3 = equipmentRepository.save(EquipmentFixture.builder().modelName("모델이름3").totalQuantity(4).build());
 
         final ReservationSpecBuilder rentalSpec1Builder = ReservationSpecFixture.builder(equipment1);
-        final ReservationSpec reservationSpec1 = rentalSpec1Builder.amount(new RentalAmount(2)).period(new RentalPeriod(NOW, NOW.plusDays(2))).build();
-        final ReservationSpec reservationSpec2 = rentalSpec1Builder.amount(new RentalAmount(1)).period(new RentalPeriod(NOW, NOW.plusDays(1))).build();
-        final ReservationSpec reservationSpec3 = rentalSpec1Builder.amount(new RentalAmount(1)).period(new RentalPeriod(NOW.plusDays(1), NOW.plusDays(2))).build();
+        final ReservationSpec reservationSpec1 = rentalSpec1Builder.amount(RentalAmount.ofPositive(2)).period(new RentalPeriod(NOW, NOW.plusDays(2))).build();
+        final ReservationSpec reservationSpec2 = rentalSpec1Builder.amount(RentalAmount.ofPositive(1)).period(new RentalPeriod(NOW, NOW.plusDays(1))).build();
+        final ReservationSpec reservationSpec3 = rentalSpec1Builder.amount(RentalAmount.ofPositive(1)).period(new RentalPeriod(NOW.plusDays(1), NOW.plusDays(2))).build();
         reservationSpecRepository.save(reservationSpec1);
         reservationSpecRepository.save(reservationSpec2);
         reservationSpecRepository.save(reservationSpec3);

--- a/src/test/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImplTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/service/RemainingQuantityServiceImplTest.java
@@ -44,9 +44,9 @@ class RemainingQuantityServiceImplTest {
     void validateAmount() {
         // given
         final Equipment equipment = EquipmentFixture.builder().id(1L).totalQuantity(2).build();
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment).amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment).amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2))).build();
 
         given(equipmentRepository.findById(any())).willReturn(Optional.of(equipment));
@@ -62,9 +62,9 @@ class RemainingQuantityServiceImplTest {
     void validateAmount_notEnoughRemainingAmount() {
         // given
         final Equipment equipment = EquipmentFixture.builder().id(1L).totalQuantity(2).build();
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment).amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment).amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(LocalDate.now(), LocalDate.now().plusDays(1))).build();
 
         given(equipmentRepository.findById(any())).willReturn(Optional.of(equipment));
@@ -81,13 +81,13 @@ class RemainingQuantityServiceImplTest {
         // given
         final Equipment equipment = EquipmentFixture.builder().id(1L).totalQuantity(2).build();
         final LocalDate monday = LocalDate.of(2023, 5, 15);
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment).amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(monday, monday.plusDays(1))).build();
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment).amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(monday.plusDays(1), monday.plusDays(2))).build();
-        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(equipment).amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(monday.plusDays(2), monday.plusDays(3))).build();
-        final ReservationSpec reservationSpec4 = ReservationSpecFixture.builder(equipment).amount(new RentalAmount(1))
+        final ReservationSpec reservationSpec4 = ReservationSpecFixture.builder(equipment).amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(monday.plusDays(3), monday.plusDays(4))).build();
         given(reservationSpecRepository.findOverlappedBetween(any(), any(), any()))
                 .willReturn(List.of(reservationSpec1, reservationSpec2, reservationSpec3, reservationSpec4));

--- a/src/test/java/com/girigiri/kwrental/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/service/ReservationServiceTest.java
@@ -31,8 +31,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.girigiri.kwrental.testsupport.DeepReflectionEqMatcher.deepRefEq;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -190,5 +192,59 @@ class ReservationServiceTest {
         // when, then
         assertThatThrownBy(() -> reservationService.getReservationWithReservationSpecsById(1L))
                 .isExactlyInstanceOf(ReservationNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("대여 예약 상세를 전량 취소하고 대여 예약이 취소된다.")
+    void cancelReservationSpec_cancelReservation() {
+        // given
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(null).id(1L).amount(RentalAmount.ofPositive(2)).build();
+        final ReservationSpec afterCanceledSpec = ReservationSpecFixture.builder(null).id(1L).amount(RentalAmount.ofPositive(2)).build();
+        afterCanceledSpec.cancelAmount(2);
+        final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec)).terminated(false).build();
+        final Reservation afterCanceledReservation = ReservationFixture.builder(List.of(afterCanceledSpec)).terminated(true).build();
+        reservation.updateIfTerminated();
+
+        given(reservationSpecRepository.findById(any())).willReturn(Optional.of(reservationSpec));
+        doNothing().when(reservationSpecRepository).adjustAmountAndStatus(deepRefEq(afterCanceledSpec, "reservation"));
+        given(reservationRepository.findByIdWithSpecs(any())).willReturn(Optional.of(reservation));
+        doNothing().when(reservationRepository).adjustTerminated(deepRefEq(afterCanceledReservation));
+
+        // when
+        final Long actual = reservationService.cancelReservationSpec(any(), 2);
+
+        // then
+        assertAll(
+                () -> assertThat(reservationSpec).usingRecursiveComparison().isEqualTo(afterCanceledSpec),
+                () -> assertThat(reservation).usingRecursiveComparison().isEqualTo(afterCanceledReservation),
+                () -> assertThat(actual).isEqualTo(reservationSpec.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("대여 예약 상세를 전량 취소하지만 대여 예약이 종결되지 않아 취소되지 않는다.")
+    void cancelReservationSpec() {
+        // given
+        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null).id(1L).amount(RentalAmount.ofPositive(2)).build();
+        final ReservationSpec afterCanceledSpec = ReservationSpecFixture.builder(null).id(1L).amount(RentalAmount.ofPositive(2)).build();
+        afterCanceledSpec.cancelAmount(2);
+        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null).id(2L).amount(RentalAmount.ofPositive(2)).build();
+        final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).terminated(false).build();
+        final Reservation afterCanceledReservation = ReservationFixture.builder(List.of(afterCanceledSpec, reservationSpec2)).terminated(false).build();
+        reservation.updateIfTerminated();
+
+        given(reservationSpecRepository.findById(any())).willReturn(Optional.of(reservationSpec1));
+        doNothing().when(reservationSpecRepository).adjustAmountAndStatus(deepRefEq(afterCanceledSpec, "reservation"));
+        given(reservationRepository.findByIdWithSpecs(any())).willReturn(Optional.of(reservation));
+
+        // when
+        final Long actual = reservationService.cancelReservationSpec(any(), 2);
+
+        // then
+        assertAll(
+                () -> assertThat(reservationSpec1).usingRecursiveComparison().isEqualTo(afterCanceledSpec),
+                () -> assertThat(reservation).usingRecursiveComparison().isEqualTo(afterCanceledReservation),
+                () -> assertThat(actual).isEqualTo(reservationSpec1.getId())
+        );
     }
 }

--- a/src/test/java/com/girigiri/kwrental/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/reservation/service/ReservationServiceTest.java
@@ -125,7 +125,7 @@ class ReservationServiceTest {
     void validatePropertyNumbersCountAndGroupByEquipmentId() {
         // given
         final Equipment equipment = EquipmentFixture.builder().id(1L).build();
-        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(equipment).id(2L).amount(new RentalAmount(2)).build();
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(equipment).id(2L).amount(RentalAmount.ofPositive(2)).build();
         final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec)).id(3L).build();
         given(reservationRepository.findByIdWithSpecs(any())).willReturn(Optional.of(reservation));
 
@@ -143,7 +143,7 @@ class ReservationServiceTest {
     void validatePropertyNumbersCountAndGroupByEquipmentId_notSameAmount() {
         // given
         final Equipment equipment = EquipmentFixture.builder().id(1L).build();
-        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(equipment).id(2L).amount(new RentalAmount(1)).build();
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(equipment).id(2L).amount(RentalAmount.ofPositive(1)).build();
         final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec)).id(3L).build();
         given(reservationRepository.findByIdWithSpecs(any())).willReturn(Optional.of(reservation));
 
@@ -158,7 +158,7 @@ class ReservationServiceTest {
     void validatePropertyNumbersCountAndGroupByEquipmentId_notFoundReservationSpec() {
         // given
         final Equipment equipment = EquipmentFixture.builder().id(1L).build();
-        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(equipment).id(2L).amount(new RentalAmount(1)).build();
+        final ReservationSpec reservationSpec = ReservationSpecFixture.builder(equipment).id(2L).amount(RentalAmount.ofPositive(1)).build();
         final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec)).id(3L).build();
         given(reservationRepository.findByIdWithSpecs(any())).willReturn(Optional.of(reservation));
 

--- a/src/test/java/com/girigiri/kwrental/testsupport/DeepReflectionEqMatcher.java
+++ b/src/test/java/com/girigiri/kwrental/testsupport/DeepReflectionEqMatcher.java
@@ -1,0 +1,53 @@
+package com.girigiri.kwrental.testsupport;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+
+public class DeepReflectionEqMatcher<T> implements ArgumentMatcher<T> {
+
+    private final T expect;
+    private final String[] ignoreFields;
+
+    public DeepReflectionEqMatcher(final T expect, final String... ignoreFields) {
+        this.expect = expect;
+        this.ignoreFields = ignoreFields;
+    }
+
+    public static <T> T deepRefEq(final T value, final String... ignoreFields) {
+        return argThat(new DeepReflectionEqMatcher<>(value, ignoreFields));
+    }
+
+    @Override
+    public boolean matches(final T argument) {
+        if (Collection.class.isAssignableFrom(argument.getClass())) {
+            return checkCollection((Collection<?>) argument);
+
+        }
+        return checkNonCollection(argument);
+    }
+
+    private boolean checkCollection(final Collection<?> argument) {
+        try {
+            assertThat(argument).usingRecursiveFieldByFieldElementComparatorIgnoringFields(ignoreFields)
+                    .isEqualTo(expect);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean checkNonCollection(final T argument) {
+        try {
+            assertThat(argument).usingRecursiveComparison()
+                    .ignoringFields(ignoreFields)
+                    .isEqualTo(expect);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/girigiri/kwrental/testsupport/fixture/InventoryFixture.java
+++ b/src/test/java/com/girigiri/kwrental/testsupport/fixture/InventoryFixture.java
@@ -20,7 +20,7 @@ public class InventoryFixture {
         final LocalDate rentalEndDate = rentalStartDate.plusDays(1);
 
         return Inventory.builder()
-                .rentalAmount(new RentalAmount(1))
+                .rentalAmount(RentalAmount.ofPositive(1))
                 .rentalPeriod(new RentalPeriod(rentalStartDate, rentalEndDate))
                 .equipment(equipment)
                 .memberId(0L);

--- a/src/test/java/com/girigiri/kwrental/testsupport/fixture/ReservationSpecFixture.java
+++ b/src/test/java/com/girigiri/kwrental/testsupport/fixture/ReservationSpecFixture.java
@@ -17,7 +17,7 @@ public class ReservationSpecFixture {
 
     public static ReservationSpecBuilder builder(final Equipment equipment) {
         return ReservationSpec.builder()
-                .amount(new RentalAmount(1))
+                .amount(RentalAmount.ofPositive(1))
                 .period(new RentalPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(2)))
                 .equipment(equipment);
     }


### PR DESCRIPTION
대여 예약 상세에서 설정한 갯수의 일부나 전체를 취소한다.
이때 전부를 취소하는 경우 대여 예약 상세의 상태가 취소로 변경되어야 한다.
그리고 대여 예약의 대여 상세가 모두 취소 상태로 변경된다면, 대여 예약은 종결되어야 한다.