### PR TITLE
랩실 운영 요일 정책에 따라 대여 일수 계산 로직 변경

### DIFF
--- a/src/main/java/com/girigiri/kwrental/inventory/domain/Inventory.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/Inventory.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 
 import java.util.Objects;
 
-// TODO: 2023/04/05 회원 관련 코드가 필요하다
 @Entity
 @Getter
 @Builder

--- a/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
+++ b/src/main/java/com/girigiri/kwrental/inventory/domain/RentalPeriod.java
@@ -6,8 +6,8 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 
 @Embeddable
 @Getter
@@ -38,9 +38,20 @@ public class RentalPeriod implements Comparable<RentalPeriod> {
         this.rentalEndDate = rentalEndDate;
     }
 
-
     public Integer getRentalDays() {
-        return (int) rentalStartDate.until(rentalEndDate, ChronoUnit.DAYS);
+        int rentalDays = 0;
+        for (LocalDate date = rentalStartDate; date.isBefore(rentalEndDate); date = date.plusDays(1)) {
+            if (isNotSupportedDayOfWeek(date)) {
+                continue;
+            }
+            rentalDays++;
+        }
+        return rentalDays;
+    }
+
+    public static boolean isNotSupportedDayOfWeek(final LocalDate date) {
+        return date.getDayOfWeek().equals(DayOfWeek.FRIDAY) || date.getDayOfWeek().equals(DayOfWeek.SATURDAY)
+                || date.getDayOfWeek().equals(DayOfWeek.SUNDAY);
     }
 
     public boolean contains(final LocalDate date) {

--- a/src/test/java/com/girigiri/kwrental/inventory/domain/RentalPeriodTest.java
+++ b/src/test/java/com/girigiri/kwrental/inventory/domain/RentalPeriodTest.java
@@ -31,15 +31,15 @@ class RentalPeriodTest {
     @DisplayName("대여 가능한 일 수를 계산한다")
     void getRentalDays() {
         // given
-        final LocalDate start = LocalDate.now().plusDays(1);
-        final LocalDate end = LocalDate.now().plusDays(1);
-        final RentalPeriod rentalPeriod = new RentalPeriod(start, end);
+        final LocalDate thursday = LocalDate.of(2023, 5, 18);
+        final LocalDate monday = LocalDate.of(2023, 5, 22);
+        final RentalPeriod rentalPeriod = new RentalPeriod(thursday, monday);
 
         // when
         final Integer expect = rentalPeriod.getRentalDays();
 
         // then
-        assertThat(expect).isZero();
+        assertThat(expect).isOne();
     }
 
     @Test


### PR DESCRIPTION
랩실은 월~목 운영한다. 이때 시스템에서는 대여 일수를 랩실 운영 요일만 카운트하도록 구현했다. 목요일 수령 월요일반납도 대여 일수가 하루가 되도록 구현했다.