### PR TITLE
대여 이력 조회 시 중복 데이터가 발생하는 현상 해결

### DIFF
--- a/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalsDto.java
+++ b/src/main/java/com/girigiri/kwrental/rental/dto/response/RentalsDto.java
@@ -3,17 +3,17 @@ package com.girigiri.kwrental.rental.dto.response;
 import com.girigiri.kwrental.rental.repository.dto.RentalDto;
 import lombok.Getter;
 
-import java.util.List;
+import java.util.Set;
 
 @Getter
 public class RentalsDto {
 
-    private List<RentalDto> rentals;
+    private Set<RentalDto> rentals;
 
     private RentalsDto() {
     }
 
-    public RentalsDto(final List<RentalDto> rentals) {
+    public RentalsDto(final Set<RentalDto> rentals) {
         this.rentals = rentals;
     }
 }

--- a/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryCustomImpl.java
@@ -75,7 +75,7 @@ public class RentalSpecRepositoryCustomImpl implements RentalSpecRepositoryCusto
                 .where(reservationSpecBetweenDate(from, to))
                 .transform(groupBy(reservationSpec.period)
                         .list(Projections.constructor(RentalDto.class, reservationSpec.period.rentalStartDate, reservationSpec.period.rentalEndDate,
-                                GroupBy.set(Projections.constructor(RentalSpecDto.class, equipment.modelName, rentalSpec.status)))));
+                                GroupBy.set(Projections.constructor(RentalSpecDto.class, rentalSpec.id, equipment.modelName, rentalSpec.status)))));
     }
 
     private BooleanExpression reservationSpecBetweenDate(final LocalDate from, final LocalDate to) {

--- a/src/main/java/com/girigiri/kwrental/rental/repository/dto/RentalDto.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/dto/RentalDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 @Getter
@@ -18,5 +19,18 @@ public class RentalDto {
         this.startDate = startDate;
         this.endDate = endDate;
         this.rentalSpecs = new HashSet<>(rentalSpecs);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RentalDto rentalDto = (RentalDto) o;
+        return Objects.equals(startDate, rentalDto.startDate) && Objects.equals(endDate, rentalDto.endDate) && Objects.equals(rentalSpecs, rentalDto.rentalSpecs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startDate, endDate, rentalSpecs);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/rental/repository/dto/RentalSpecDto.java
+++ b/src/main/java/com/girigiri/kwrental/rental/repository/dto/RentalSpecDto.java
@@ -9,13 +9,15 @@ import java.util.Objects;
 
 public class RentalSpecDto {
 
+    private Long id;
     private String modelName;
     private RentalSpecStatus status;
 
     protected RentalSpecDto() {
     }
 
-    public RentalSpecDto(final String modelName, final RentalSpecStatus status) {
+    public RentalSpecDto(final Long id, final String modelName, final RentalSpecStatus status) {
+        this.id = id;
         this.modelName = modelName;
         this.status = status;
     }
@@ -25,11 +27,11 @@ public class RentalSpecDto {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final RentalSpecDto that = (RentalSpecDto) o;
-        return Objects.equals(modelName, that.modelName) && status == that.status;
+        return Objects.equals(id, that.id) && Objects.equals(modelName, that.modelName) && status == that.status;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(modelName, status);
+        return Objects.hash(id, modelName, status);
     }
 }

--- a/src/main/java/com/girigiri/kwrental/rental/service/RentalService.java
+++ b/src/main/java/com/girigiri/kwrental/rental/service/RentalService.java
@@ -16,6 +16,7 @@ import com.girigiri.kwrental.rental.dto.response.overduereservations.OverdueRese
 import com.girigiri.kwrental.rental.dto.response.reservationsWithRentalSpecs.ReservationsWithRentalSpecsAndMemberNumberResponse;
 import com.girigiri.kwrental.rental.exception.DuplicateRentalException;
 import com.girigiri.kwrental.rental.repository.RentalSpecRepository;
+import com.girigiri.kwrental.rental.repository.dto.RentalDto;
 import com.girigiri.kwrental.reservation.domain.Reservation;
 import com.girigiri.kwrental.reservation.domain.Reservations;
 import com.girigiri.kwrental.reservation.repository.dto.ReservationWithMemberNumber;
@@ -155,7 +156,8 @@ public class RentalService {
 
     @Transactional(readOnly = true)
     public RentalsDto getRentalsBetweenDate(final Long memberId, final LocalDate from, final LocalDate to) {
-        return new RentalsDto(rentalSpecRepository.findRentalDtosBetweenDate(memberId, from, to));
+        final List<RentalDto> rentalDtosBetweenDate = rentalSpecRepository.findRentalDtosBetweenDate(memberId, from, to);
+        return new RentalsDto(new LinkedHashSet<>(rentalDtosBetweenDate));
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/girigiri/kwrental/acceptance/RentalAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/RentalAcceptanceTest.java
@@ -244,7 +244,7 @@ class RentalAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.getRentals()).usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(new RentalDto(reservation.getStartDate(), reservation.getEndDate(),
-                        Set.of(new RentalSpecDto(equipment1.getModelName(), rentalSpec1.getStatus()), new RentalSpecDto(equipment2.getModelName(), rentalSpec2.getStatus())))
+                        Set.of(new RentalSpecDto(rentalSpec1.getId(), equipment1.getModelName(), rentalSpec1.getStatus()), new RentalSpecDto(rentalSpec2.getId(), equipment2.getModelName(), rentalSpec2.getStatus())))
                 );
     }
 

--- a/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/repository/RentalSpecRepositoryTest.java
@@ -117,20 +117,29 @@ class RentalSpecRepositoryTest {
         final LocalDate now = LocalDate.now();
         final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment1).period(new RentalPeriod(now, now.plusDays(1))).build();
         final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(now, now.plusDays(1))).build();
-        final Reservation reservation = reservationRepository.save(ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).memberId(member.getId()).build());
+        final Reservation reservation1 = reservationRepository.save(ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).memberId(member.getId()).build());
 
-        final RentalSpec rentalSpec1 = RentalSpecFixture.builder().propertyNumber("11111111").reservationSpecId(reservationSpec1.getId()).reservationId(reservation.getId()).build();
-        final RentalSpec rentalSpec2 = RentalSpecFixture.builder().propertyNumber("22222222").reservationSpecId(reservationSpec2.getId()).reservationId(reservation.getId()).build();
-        rentalSpecRepository.saveAll(List.of(rentalSpec1, rentalSpec2));
+        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(equipment1).period(new RentalPeriod(now.plusDays(1), now.plusDays(2))).build();
+        final ReservationSpec reservationSpec4 = ReservationSpecFixture.builder(equipment2).period(new RentalPeriod(now.plusDays(1), now.plusDays(2))).build();
+        final Reservation reservation2 = reservationRepository.save(ReservationFixture.builder(List.of(reservationSpec3, reservationSpec4)).memberId(member.getId()).build());
+
+        final RentalSpec rentalSpec1 = RentalSpecFixture.builder().propertyNumber("11111111").reservationSpecId(reservationSpec1.getId()).reservationId(reservation1.getId()).build();
+        final RentalSpec rentalSpec2 = RentalSpecFixture.builder().propertyNumber("22222222").reservationSpecId(reservationSpec2.getId()).reservationId(reservation1.getId()).build();
+        final RentalSpec rentalSpec3 = RentalSpecFixture.builder().propertyNumber("33333333").reservationSpecId(reservationSpec3.getId()).reservationId(reservation2.getId()).build();
+        final RentalSpec rentalSpec4 = RentalSpecFixture.builder().propertyNumber("44444444").reservationSpecId(reservationSpec4.getId()).reservationId(reservation2.getId()).build();
+        rentalSpecRepository.saveAll(List.of(rentalSpec1, rentalSpec2, rentalSpec3, rentalSpec4));
 
         // when
-        final List<RentalDto> rentalDtos = rentalSpecRepository.findRentalDtosBetweenDate(member.getId(), now, now.plusDays(1));
+        final List<RentalDto> rentalDtos = rentalSpecRepository.findRentalDtosBetweenDate(member.getId(), now, now.plusDays(2));
 
         // then
         assertThat(rentalDtos).usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(
                         new RentalDto(reservationSpec1.getStartDate(), reservationSpec1.getEndDate(),
-                                Set.of(new RentalSpecDto(equipment1.getModelName(), rentalSpec1.getStatus()), new RentalSpecDto(equipment2.getModelName(), rentalSpec2.getStatus()))));
+                                Set.of(new RentalSpecDto(rentalSpec1.getId(), equipment1.getModelName(), rentalSpec1.getStatus()), new RentalSpecDto(rentalSpec2.getId(), equipment2.getModelName(), rentalSpec2.getStatus()))),
+                        new RentalDto(reservationSpec3.getStartDate(), reservationSpec3.getEndDate(),
+                                Set.of(new RentalSpecDto(rentalSpec3.getId(), equipment1.getModelName(), rentalSpec3.getStatus()), new RentalSpecDto(rentalSpec4.getId(), equipment2.getModelName(), rentalSpec4.getStatus())))
+                );
     }
 
     @Test


### PR DESCRIPTION
![image](https://github.com/KW-GIRIGIRI/kw-rental-backend/assets/87690744/bef90de6-605b-4853-8348-d924c7efb898)

조회된 데이터를 Set로 감싸서 중복을 제거하도록 했다. 이때 순서를 보장하기 위해 LinkedHashSet 구현체를 활용했다.
다만 중복 데이터가 왜 발생했는지는 아직 더 찾아봐야 한다.