### PR TITLE
비밀번호 변경 시 이메일이 일치하지 않으면 예외 발생하도록 수정

### DIFF
--- a/src/main/java/com/girigiri/kwrental/auth/domain/Member.java
+++ b/src/main/java/com/girigiri/kwrental/auth/domain/Member.java
@@ -86,4 +86,8 @@ public class Member {
 	public boolean isAdmin() {
 		return this.role == Role.ADMIN;
 	}
+
+	public boolean hasSameEmail(final String email) {
+		return this.email.equals(email);
+	}
 }

--- a/src/main/java/com/girigiri/kwrental/auth/exception/EmailNotMatchesException.java
+++ b/src/main/java/com/girigiri/kwrental/auth/exception/EmailNotMatchesException.java
@@ -1,0 +1,9 @@
+package com.girigiri.kwrental.auth.exception;
+
+import com.girigiri.kwrental.common.exception.BadRequestException;
+
+public class EmailNotMatchesException extends BadRequestException {
+	public EmailNotMatchesException() {
+		super("입력된 이메일이 회원의 이메일과 일치하지 않습니다!");
+	}
+}

--- a/src/main/java/com/girigiri/kwrental/auth/service/AuthService.java
+++ b/src/main/java/com/girigiri/kwrental/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import com.girigiri.kwrental.auth.dto.request.ResetPasswordRequest;
 import com.girigiri.kwrental.auth.dto.request.UpdateAdminRequest;
 import com.girigiri.kwrental.auth.dto.request.UpdateUserRequest;
 import com.girigiri.kwrental.auth.dto.response.MemberResponse;
+import com.girigiri.kwrental.auth.exception.EmailNotMatchesException;
 import com.girigiri.kwrental.auth.exception.ForbiddenException;
 import com.girigiri.kwrental.auth.exception.MemberException;
 import com.girigiri.kwrental.auth.exception.MemberNotFoundException;
@@ -99,7 +100,7 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public void checkPassword(Long id, String password) {
+    public void checkPassword(final Long id, final String password) {
         final String encodedPassword = getMember(id).getPassword();
         boolean matches = passwordEncoder.matches(password, encodedPassword);
         if (!matches) {
@@ -108,8 +109,11 @@ public class AuthService {
     }
 
     @Transactional
-    public void resetPassword(ResetPasswordRequest resetPasswordRequest) {
+    public void resetPassword(final ResetPasswordRequest resetPasswordRequest) {
         final Member member = getMemberByMemberNumber(resetPasswordRequest.getMemberNumber());
+        if (!member.hasSameEmail(resetPasswordRequest.getEmail())) {
+            throw new EmailNotMatchesException();
+        }
         final String randomPassword = getRandomPassword();
         final String encodedPassword = passwordEncoder.encode(randomPassword);
         member.updatePassword(encodedPassword);

--- a/src/test/java/com/girigiri/kwrental/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/AuthAcceptanceTest.java
@@ -220,11 +220,13 @@ class AuthAcceptanceTest extends AcceptanceTest {
 	void resetPassword() {
 		// given
 		final String password = "12345678";
-		final Member member = memberRepository.save(MemberFixture.builder(password).role(Role.USER).build());
+		final String email = "djwhy5510@naver.com";
+		final Member member = memberRepository.save(
+			MemberFixture.builder(password).role(Role.USER).email(email).build());
 		final String sessionId = getSessionId(member.getMemberNumber(), password);
 
 		final ResetPasswordRequest requestBody = new ResetPasswordRequest(member.getMemberNumber(),
-			"djwhy5510@naver.com");
+			email);
 		doNothing().when(emailService).sendRenewPassword(eq(requestBody.getEmail()), anyString());
 
 		// when


### PR DESCRIPTION
`Member` 객체에게 이메일 일치 여부를 물어보고 서비스에서 예외를 발생하도록 구현했다.
`Member` 객체에서 예외를 발생시킬 수도 있다. 다만 예외를 발생시키고 싶지 않고 일치 여부만 알고 싶을 때의 경우를 고려하면 도메인 객체에서 일치 여부만 확인하는 것이 유리하다고 판단했다.