### PR TITLE
사용자 페널티 이력에 패널티 기간 시작일과 끝일 대신 대여의 실제 수령처리일 반납처리일로 변경

### DIFF
--- a/src/main/java/com/girigiri/kwrental/penalty/domain/Penalty.java
+++ b/src/main/java/com/girigiri/kwrental/penalty/domain/Penalty.java
@@ -60,4 +60,8 @@ public class Penalty {
     public void setReason(final PenaltyReason reason) {
         this.reason = reason;
     }
+
+    public String getStatusMessage() {
+        return this.period.getStatus().getMessage();
+    }
 }

--- a/src/main/java/com/girigiri/kwrental/penalty/dto/response/UserPenaltyResponse.java
+++ b/src/main/java/com/girigiri/kwrental/penalty/dto/response/UserPenaltyResponse.java
@@ -1,17 +1,19 @@
 package com.girigiri.kwrental.penalty.dto.response;
 
+import java.time.LocalDate;
+
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.penalty.domain.PenaltyPeriod;
 import com.girigiri.kwrental.penalty.domain.PenaltyReason;
-import lombok.Getter;
 
-import java.time.LocalDate;
+import lombok.Getter;
 
 @Getter
 public class UserPenaltyResponse {
 
     private Long id;
-    private LocalDate startDate;
-    private LocalDate endDate;
+    private LocalDate acceptDate;
+    private LocalDate returnDate;
     private String status;
     private String assetName;
     private PenaltyReason reason;
@@ -19,16 +21,19 @@ public class UserPenaltyResponse {
     private UserPenaltyResponse() {
     }
 
-    public UserPenaltyResponse(final Long id, final PenaltyPeriod period,
-                               final String assetName, final PenaltyReason reason) {
-        this(id, period.getStartDate(), period.getEndDate(), period.getStatus().getMessage(), assetName, reason);
+    public UserPenaltyResponse(final Long id, final RentalDateTime acceptDate, final RentalDateTime returnDate,
+        final PenaltyPeriod period,
+        final String assetName, final PenaltyReason reason) {
+        this(id, acceptDate.toLocalDate(), returnDate.toLocalDate(), period.getStatus().getMessage(), assetName,
+            reason);
     }
 
-    private UserPenaltyResponse(final Long id, final LocalDate startDate, final LocalDate endDate, final String status,
-                                final String assetName, final PenaltyReason reason) {
+    public UserPenaltyResponse(final Long id, final LocalDate acceptDate, final LocalDate returnDate,
+        final String status,
+        final String assetName, final PenaltyReason reason) {
         this.id = id;
-        this.startDate = startDate;
-        this.endDate = endDate;
+        this.acceptDate = acceptDate;
+        this.returnDate = returnDate;
         this.status = status;
         this.assetName = assetName;
         this.reason = reason;

--- a/src/main/java/com/girigiri/kwrental/penalty/repository/PenaltyRepositoryCustomImpl.java
+++ b/src/main/java/com/girigiri/kwrental/penalty/repository/PenaltyRepositoryCustomImpl.java
@@ -1,5 +1,19 @@
 package com.girigiri.kwrental.penalty.repository;
 
+import static com.girigiri.kwrental.asset.domain.QRentableAsset.*;
+import static com.girigiri.kwrental.penalty.domain.QPenalty.*;
+import static com.girigiri.kwrental.rental.domain.QAbstractRentalSpec.*;
+import static com.girigiri.kwrental.reservation.domain.QReservation.*;
+import static com.girigiri.kwrental.reservation.domain.QReservationSpec.*;
+import static com.girigiri.kwrental.util.QueryDSLUtils.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
 import com.girigiri.kwrental.penalty.domain.Penalty;
 import com.girigiri.kwrental.penalty.dto.response.PenaltyHistoryResponse;
 import com.girigiri.kwrental.penalty.dto.response.UserPenaltiesResponse;
@@ -7,68 +21,59 @@ import com.girigiri.kwrental.penalty.dto.response.UserPenaltyResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-
-import java.time.LocalDate;
-import java.util.List;
-
-import static com.girigiri.kwrental.asset.domain.QRentableAsset.rentableAsset;
-import static com.girigiri.kwrental.penalty.domain.QPenalty.penalty;
-import static com.girigiri.kwrental.reservation.domain.QReservation.reservation;
-import static com.girigiri.kwrental.reservation.domain.QReservationSpec.reservationSpec;
-import static com.girigiri.kwrental.util.QueryDSLUtils.setPageable;
 
 public class PenaltyRepositoryCustomImpl implements PenaltyRepositoryCustom {
 
-    private final JPAQueryFactory queryFactory;
+	private final JPAQueryFactory queryFactory;
 
-    public PenaltyRepositoryCustomImpl(final JPAQueryFactory queryFactory) {
-        this.queryFactory = queryFactory;
-    }
+	public PenaltyRepositoryCustomImpl(final JPAQueryFactory queryFactory) {
+		this.queryFactory = queryFactory;
+	}
 
-    @Override
-    public List<Penalty> findByOngoingPenalties(final Long memberId) {
-        final LocalDate now = LocalDate.now();
-        return queryFactory
-                .selectFrom(penalty)
-                .where(penalty.memberId.eq(memberId),
-                        penalty.period.startDate.loe(now),
-                        penalty.period.endDate.goe(now))
-                .fetch();
-    }
+	@Override
+	public List<Penalty> findByOngoingPenalties(final Long memberId) {
+		final LocalDate now = LocalDate.now();
+		return queryFactory
+			.selectFrom(penalty)
+			.where(penalty.memberId.eq(memberId),
+				penalty.period.startDate.loe(now),
+				penalty.period.endDate.goe(now))
+			.fetch();
+	}
 
-    @Override
-    public UserPenaltiesResponse findUserPenaltiesResponseByMemberId(final Long memberId) {
-        final List<UserPenaltyResponse> userPenaltyResponses = queryFactory
-                .from(penalty)
-                .join(reservationSpec).on(reservationSpec.id.eq(penalty.reservationSpecId))
-                .join(rentableAsset).on(rentableAsset.id.eq(reservationSpec.rentable.id))
-                .where(penalty.memberId.eq(memberId))
-                .select(Projections.constructor(UserPenaltyResponse.class, penalty.id, penalty.period, rentableAsset.name, penalty.reason))
-                .fetch();
-        return new UserPenaltiesResponse(userPenaltyResponses);
-    }
+	@Override
+	public UserPenaltiesResponse findUserPenaltiesResponseByMemberId(final Long memberId) {
+		final List<UserPenaltyResponse> userPenaltyResponses = queryFactory
+			.from(penalty)
+			.join(reservationSpec).on(reservationSpec.id.eq(penalty.reservationSpecId))
+			.join(rentableAsset).on(rentableAsset.id.eq(reservationSpec.rentable.id))
+			.join(abstractRentalSpec).on(abstractRentalSpec.id.eq(penalty.rentalSpecId))
+			.where(penalty.memberId.eq(memberId))
+			.select(Projections.constructor(UserPenaltyResponse.class, penalty.id, abstractRentalSpec.acceptDateTime,
+				abstractRentalSpec.returnDateTime, penalty.period, rentableAsset.name,
+				penalty.reason))
+			.fetch();
+		return new UserPenaltiesResponse(userPenaltyResponses);
+	}
 
-    @Override
-    public Page<PenaltyHistoryResponse> findPenaltyHistoryPageResponse(final Pageable pageable) {
-        final JPAQuery<PenaltyHistoryResponse> query = queryFactory
-                .from(penalty)
-                .join(reservationSpec).on(reservationSpec.id.eq(penalty.reservationSpecId))
-                .join(rentableAsset).on(rentableAsset.id.eq(reservationSpec.rentable.id))
-                .join(reservation).on(reservation.id.eq(penalty.reservationId))
-                .select(Projections.constructor(PenaltyHistoryResponse.class,
-                        penalty.id, reservation.name, penalty.period, rentableAsset.name, penalty.reason));
-        setPageable(query, penalty, pageable);
-        return new PageImpl<>(query.fetch(), pageable, countAll());
-    }
+	@Override
+	public Page<PenaltyHistoryResponse> findPenaltyHistoryPageResponse(final Pageable pageable) {
+		final JPAQuery<PenaltyHistoryResponse> query = queryFactory
+			.from(penalty)
+			.join(reservationSpec).on(reservationSpec.id.eq(penalty.reservationSpecId))
+			.join(rentableAsset).on(rentableAsset.id.eq(reservationSpec.rentable.id))
+			.join(reservation).on(reservation.id.eq(penalty.reservationId))
+			.select(Projections.constructor(PenaltyHistoryResponse.class,
+				penalty.id, reservation.name, penalty.period, rentableAsset.name, penalty.reason));
+		setPageable(query, penalty, pageable);
+		return new PageImpl<>(query.fetch(), pageable, countAll());
+	}
 
-    private long countAll() {
-        final Long count = queryFactory
-                .select(penalty.count())
-                .from(penalty)
-                .fetchOne();
-        return count == null ? 0 : count;
-    }
+	private long countAll() {
+		final Long count = queryFactory
+			.select(penalty.count())
+			.from(penalty)
+			.fetchOne();
+		return count == null ? 0 : count;
+	}
 }

--- a/src/main/java/com/girigiri/kwrental/rental/domain/AbstractRentalSpec.java
+++ b/src/main/java/com/girigiri/kwrental/rental/domain/AbstractRentalSpec.java
@@ -1,19 +1,28 @@
 package com.girigiri.kwrental.rental.domain;
 
+import java.time.LocalDateTime;
+
 import com.girigiri.kwrental.common.AbstractSuperEntity;
 import com.girigiri.kwrental.inventory.domain.RentalDateTime;
-import jakarta.persistence.*;
-import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @Entity
 @Getter
 @Table(name = "rental_spec")
-@EntityListeners(AuditingEntityListener.class)
 public abstract class AbstractRentalSpec extends AbstractSuperEntity implements RentalSpec {
 
     @Id
@@ -30,7 +39,6 @@ public abstract class AbstractRentalSpec extends AbstractSuperEntity implements 
     @Column(nullable = false)
     private RentalSpecStatus status = RentalSpecStatus.RENTED;
 
-    @CreatedDate
     @Embedded
     @AttributeOverride(name = "instant", column = @Column(name = "accept_date_time"))
     private RentalDateTime acceptDateTime;
@@ -47,8 +55,12 @@ public abstract class AbstractRentalSpec extends AbstractSuperEntity implements 
         this.id = id;
         this.reservationSpecId = reservationSpecId;
         this.reservationId = reservationId;
-        if (status != null) this.status = status;
-        this.acceptDateTime = acceptDateTime;
+        if (status != null)
+            this.status = status;
+        if (acceptDateTime == null)
+            this.acceptDateTime = RentalDateTime.now();
+        if (acceptDateTime != null)
+            this.acceptDateTime = acceptDateTime;
         this.returnDateTime = returnDateTime;
     }
 

--- a/src/main/java/com/girigiri/kwrental/rental/service/RentalService.java
+++ b/src/main/java/com/girigiri/kwrental/rental/service/RentalService.java
@@ -116,6 +116,7 @@ public class RentalService {
 			.reservationId(reservationId)
 			.reservationSpecId(reservationSpecId)
 			.propertyNumber(propertyNumber)
+			.acceptDateTime(RentalDateTime.now())
 			.build();
 	}
 
@@ -249,6 +250,7 @@ public class RentalService {
 		return LabRoomRentalSpec.builder()
 			.reservationId(reservationId)
 			.reservationSpecId(reservationSpecId)
+			.acceptDateTime(RentalDateTime.now())
 			.build();
 	}
 

--- a/src/test/java/com/girigiri/kwrental/acceptance/PenaltyAcceptanceTest.java
+++ b/src/test/java/com/girigiri/kwrental/acceptance/PenaltyAcceptanceTest.java
@@ -1,15 +1,31 @@
 package com.girigiri.kwrental.acceptance;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
 import com.girigiri.kwrental.asset.domain.Rentable;
 import com.girigiri.kwrental.asset.repository.AssetRepository;
 import com.girigiri.kwrental.auth.domain.Member;
 import com.girigiri.kwrental.auth.repository.MemberRepository;
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.penalty.domain.Penalty;
 import com.girigiri.kwrental.penalty.domain.PenaltyPeriod;
 import com.girigiri.kwrental.penalty.domain.PenaltyReason;
 import com.girigiri.kwrental.penalty.domain.PenaltyStatus;
 import com.girigiri.kwrental.penalty.dto.request.UpdatePeriodRequest;
-import com.girigiri.kwrental.penalty.dto.response.*;
+import com.girigiri.kwrental.penalty.dto.response.PenaltyHistoryPageResponse;
+import com.girigiri.kwrental.penalty.dto.response.PenaltyHistoryResponse;
+import com.girigiri.kwrental.penalty.dto.response.UserPenaltiesResponse;
+import com.girigiri.kwrental.penalty.dto.response.UserPenaltyResponse;
+import com.girigiri.kwrental.penalty.dto.response.UserPenaltyStatusResponse;
 import com.girigiri.kwrental.penalty.repository.PenaltyRepository;
 import com.girigiri.kwrental.rental.domain.EquipmentRentalSpec;
 import com.girigiri.kwrental.rental.domain.LabRoomRentalSpec;
@@ -17,201 +33,272 @@ import com.girigiri.kwrental.rental.repository.RentalSpecRepository;
 import com.girigiri.kwrental.reservation.domain.Reservation;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.repository.ReservationRepository;
-import com.girigiri.kwrental.testsupport.fixture.*;
+import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
+import com.girigiri.kwrental.testsupport.fixture.EquipmentRentalSpecFixture;
+import com.girigiri.kwrental.testsupport.fixture.LabRoomFixture;
+import com.girigiri.kwrental.testsupport.fixture.LabRoomRentalSpecFixture;
+import com.girigiri.kwrental.testsupport.fixture.MemberFixture;
+import com.girigiri.kwrental.testsupport.fixture.PenaltyFixture;
+import com.girigiri.kwrental.testsupport.fixture.ReservationFixture;
+import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
+
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
 
 class PenaltyAcceptanceTest extends AcceptanceTest {
 
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private AssetRepository assetRepository;
-    @Autowired
-    private ReservationRepository reservationRepository;
-    @Autowired
-    private RentalSpecRepository rentalSpecRepository;
-    @Autowired
-    private PenaltyRepository penaltyRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private AssetRepository assetRepository;
+	@Autowired
+	private ReservationRepository reservationRepository;
+	@Autowired
+	private RentalSpecRepository rentalSpecRepository;
+	@Autowired
+	private PenaltyRepository penaltyRepository;
 
-    @Test
-    @DisplayName("특정 사용자의 페널티 이력을 조회한다.")
-    void penaltiesByMember() {
-        // given
-        final String password = "12345678";
-        final Member member = memberRepository.save(MemberFixture.create(password));
-        final String sessionId = getSessionId(member.getMemberNumber(), password);
+	@Test
+	@DisplayName("특정 사용자의 페널티 이력을 조회한다.")
+	void penaltiesByMember() {
+		// given
+		final String password = "12345678";
+		final Member member = memberRepository.save(MemberFixture.create(password));
+		final String sessionId = getSessionId(member.getMemberNumber(), password);
 
-        final Rentable equipment = assetRepository.save(EquipmentFixture.create());
-        final Rentable labRoom = assetRepository.save(LabRoomFixture.create());
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
-        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1)));
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.create(labRoom);
-        final Reservation reservation2 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec2)));
+		final Rentable equipment = assetRepository.save(EquipmentFixture.create());
+		final Rentable labRoom = assetRepository.save(LabRoomFixture.create());
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
+		final Reservation reservation1 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec1)));
+		final ReservationSpec reservationSpec2 = ReservationSpecFixture.create(labRoom);
+		final Reservation reservation2 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec2)));
 
-        final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder().reservationId(reservation1.getId()).reservationSpecId(reservationSpec1.getId()).build();
-        final LabRoomRentalSpec labRoomRentalSpec = LabRoomRentalSpecFixture.builder().reservationId(reservation2.getId()).reservationSpecId(reservationSpec2.getId()).build();
-        rentalSpecRepository.saveAll(List.of(equipmentRentalSpec, labRoomRentalSpec));
+		final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservation1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.acceptDateTime(RentalDateTime.now().calculateDay(-1))
+			.returnDateTime(RentalDateTime.now())
+			.build();
+		final LabRoomRentalSpec labRoomRentalSpec = LabRoomRentalSpecFixture.builder()
+			.reservationId(reservation2.getId())
+			.reservationSpecId(reservationSpec2.getId())
+			.acceptDateTime(RentalDateTime.now().calculateDay(-2))
+			.returnDateTime(RentalDateTime.now())
+			.build();
+		rentalSpecRepository.saveAll(List.of(equipmentRentalSpec, labRoomRentalSpec));
 
-        final Long memberId = member.getId();
-        final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(memberId).reservationId(reservation1.getId()).rentalSpecId(reservationSpec1.getId())
-                .reservationSpecId(reservationSpec1.getId()).period(PenaltyPeriod.fromPenaltyCount(0)).build());
-        final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.LOST).memberId(memberId).reservationId(reservation2.getId()).rentalSpecId(reservationSpec2.getId())
-                .reservationSpecId(reservationSpec2.getId()).period(PenaltyPeriod.fromPenaltyCount(1)).build());
+		final Long memberId = member.getId();
+		final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN)
+			.memberId(memberId)
+			.reservationId(reservation1.getId())
+			.rentalSpecId(equipmentRentalSpec.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(0))
+			.build());
+		final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.LOST)
+			.memberId(memberId)
+			.reservationId(reservation2.getId())
+			.rentalSpecId(labRoomRentalSpec.getId())
+			.reservationSpecId(reservationSpec2.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(1))
+			.build());
 
-        // when
-        final UserPenaltiesResponse response = RestAssured.given(requestSpec)
-                .sessionId(sessionId)
-                .filter(document("getPenaltyByMember"))
-                .when().log().all().get("/api/penalties")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(UserPenaltiesResponse.class);
+		// when
+		final UserPenaltiesResponse response = RestAssured.given(requestSpec)
+			.sessionId(sessionId)
+			.filter(document("getPenaltyByMember"))
+			.when().log().all().get("/api/penalties")
+			.then().log().all()
+			.statusCode(HttpStatus.OK.value())
+			.extract().as(UserPenaltiesResponse.class);
 
-        // then
-        assertThat(response.getPenalties()).usingRecursiveFieldByFieldElementComparator()
-                .containsExactly(
-                        new UserPenaltyResponse(penalty1.getId(), penalty1.getPeriod(), equipment.getName(), penalty1.getReason()),
-                        new UserPenaltyResponse(penalty2.getId(), penalty2.getPeriod(), labRoom.getName(), penalty2.getReason())
-                );
-    }
+		// then
+		assertThat(response.getPenalties()).usingRecursiveFieldByFieldElementComparator()
+			.containsExactly(
+				new UserPenaltyResponse(penalty1.getId(), RentalDateTime.now().calculateDay(-1).toLocalDate(),
+					RentalDateTime.now().toLocalDate(), penalty1.getStatusMessage(), equipment.getName(),
+					penalty1.getReason()),
+				new UserPenaltyResponse(penalty2.getId(), RentalDateTime.now().calculateDay(-2).toLocalDate(),
+					RentalDateTime.now().toLocalDate(), penalty2.getStatusMessage(), labRoom.getName(),
+					penalty2.getReason())
+			);
+	}
 
-    @Test
-    @DisplayName("회원의 페널티 상태를 조회한다.")
-    void getUserPenaltyStatus() {
-        // given
-        final String password = "12345678";
-        final Member member = memberRepository.save(MemberFixture.create(password));
-        final String sessionId = getSessionId(member.getMemberNumber(), password);
+	@Test
+	@DisplayName("회원의 페널티 상태를 조회한다.")
+	void getUserPenaltyStatus() {
+		// given
+		final String password = "12345678";
+		final Member member = memberRepository.save(MemberFixture.create(password));
+		final String sessionId = getSessionId(member.getMemberNumber(), password);
 
-        final Rentable equipment = assetRepository.save(EquipmentFixture.create());
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
-        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1)));
+		final Rentable equipment = assetRepository.save(EquipmentFixture.create());
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
+		final Reservation reservation1 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec1)));
 
-        final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder().reservationId(reservation1.getId()).reservationSpecId(reservationSpec1.getId()).build();
-        rentalSpecRepository.saveAll(List.of(equipmentRentalSpec));
+		final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservation1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.build();
+		rentalSpecRepository.saveAll(List.of(equipmentRentalSpec));
 
-        final Long memberId = member.getId();
-        final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(memberId).reservationId(reservation1.getId()).rentalSpecId(reservationSpec1.getId())
-                .reservationSpecId(reservationSpec1.getId()).period(PenaltyPeriod.fromPenaltyCount(0)).build());
+		final Long memberId = member.getId();
+		final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN)
+			.memberId(memberId)
+			.reservationId(reservation1.getId())
+			.rentalSpecId(reservationSpec1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(0))
+			.build());
 
-        // when
-        final UserPenaltyStatusResponse response = RestAssured.given(requestSpec)
-                .sessionId(sessionId)
-                .filter(document("getUserPenaltyStatus"))
-                .when().log().all().get("/api/penalties/status")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(UserPenaltyStatusResponse.class);
+		// when
+		final UserPenaltyStatusResponse response = RestAssured.given(requestSpec)
+			.sessionId(sessionId)
+			.filter(document("getUserPenaltyStatus"))
+			.when().log().all().get("/api/penalties/status")
+			.then().log().all()
+			.statusCode(HttpStatus.OK.value())
+			.extract().as(UserPenaltyStatusResponse.class);
 
-        // then
-        assertThat(response).usingRecursiveComparison()
-                .isEqualTo(new UserPenaltyStatusResponse(false, penalty1.getPeriod().getStatus(), penalty1.getPeriod().getEndDate()));
-    }
+		// then
+		assertThat(response).usingRecursiveComparison()
+			.isEqualTo(new UserPenaltyStatusResponse(false, penalty1.getPeriod().getStatus(),
+				penalty1.getPeriod().getEndDate()));
+	}
 
-    @Test
-    @DisplayName("패널티 히스토리를 조회한다.")
-    void getPenaltyHistoryPage() {
-        // given
-        final Rentable equipment = assetRepository.save(EquipmentFixture.create());
-        final Rentable labRoom = assetRepository.save(LabRoomFixture.create());
+	@Test
+	@DisplayName("패널티 히스토리를 조회한다.")
+	void getPenaltyHistoryPage() {
+		// given
+		final Rentable equipment = assetRepository.save(EquipmentFixture.create());
+		final Rentable labRoom = assetRepository.save(LabRoomFixture.create());
 
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
-        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1)));
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.create(labRoom);
-        final Reservation reservation2 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec2)));
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
+		final Reservation reservation1 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec1)));
+		final ReservationSpec reservationSpec2 = ReservationSpecFixture.create(labRoom);
+		final Reservation reservation2 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec2)));
 
-        final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder().reservationId(reservation1.getId()).reservationSpecId(reservationSpec1.getId()).build();
-        final LabRoomRentalSpec labRoomRentalSpec = LabRoomRentalSpecFixture.builder().reservationId(reservation2.getId()).reservationSpecId(reservationSpec2.getId()).build();
-        rentalSpecRepository.saveAll(List.of(equipmentRentalSpec, labRoomRentalSpec));
+		final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservation1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.build();
+		final LabRoomRentalSpec labRoomRentalSpec = LabRoomRentalSpecFixture.builder()
+			.reservationId(reservation2.getId())
+			.reservationSpecId(reservationSpec2.getId())
+			.build();
+		rentalSpecRepository.saveAll(List.of(equipmentRentalSpec, labRoomRentalSpec));
 
-        final Long memberId = 1L;
-        final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(memberId).reservationId(reservation1.getId()).rentalSpecId(reservationSpec1.getId())
-                .reservationSpecId(reservationSpec1.getId()).period(PenaltyPeriod.fromPenaltyCount(0)).build());
-        final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.LOST).memberId(0L).reservationId(reservation2.getId()).rentalSpecId(reservationSpec2.getId())
-                .reservationSpecId(reservationSpec2.getId()).period(PenaltyPeriod.fromPenaltyCount(1)).build());
+		final Long memberId = 1L;
+		final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN)
+			.memberId(memberId)
+			.reservationId(reservation1.getId())
+			.rentalSpecId(reservationSpec1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(0))
+			.build());
+		final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.LOST)
+			.memberId(0L)
+			.reservationId(reservation2.getId())
+			.rentalSpecId(reservationSpec2.getId())
+			.reservationSpecId(reservationSpec2.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(1))
+			.build());
 
-        // when
-        final PenaltyHistoryPageResponse response = RestAssured.given(requestSpec)
-                .filter(document("getPenaltyHistoryPage"))
-                .when().log().all().get("/api/admin/penalties/histories?size={size}&page={page}", 1, 0)
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(PenaltyHistoryPageResponse.class);
+		// when
+		final PenaltyHistoryPageResponse response = RestAssured.given(requestSpec)
+			.filter(document("getPenaltyHistoryPage"))
+			.when().log().all().get("/api/admin/penalties/histories?size={size}&page={page}", 1, 0)
+			.then().log().all()
+			.statusCode(HttpStatus.OK.value())
+			.extract().as(PenaltyHistoryPageResponse.class);
 
-        // then
-        assertThat(response.getPenalties()).usingRecursiveFieldByFieldElementComparator()
-                .containsExactly(new PenaltyHistoryResponse(penalty2.getId(), reservation2.getName(), penalty2.getPeriod(), labRoom.getName(), penalty2.getReason()));
-        assertThat(response.getEndPoints()).hasSize(2);
-    }
+		// then
+		assertThat(response.getPenalties()).usingRecursiveFieldByFieldElementComparator()
+			.containsExactly(new PenaltyHistoryResponse(penalty2.getId(), reservation2.getName(), penalty2.getPeriod(),
+				labRoom.getName(), penalty2.getReason()));
+		assertThat(response.getEndPoints()).hasSize(2);
+	}
 
-    @Test
-    @DisplayName("패널티의 기간을 수정한다.")
-    void updatePenaltyPeriod() {
-        // given
-        final Rentable equipment = assetRepository.save(EquipmentFixture.create());
+	@Test
+	@DisplayName("패널티의 기간을 수정한다.")
+	void updatePenaltyPeriod() {
+		// given
+		final Rentable equipment = assetRepository.save(EquipmentFixture.create());
 
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
-        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1)));
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
+		final Reservation reservation1 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec1)));
 
-        final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder().reservationId(reservation1.getId()).reservationSpecId(reservationSpec1.getId()).build();
-        rentalSpecRepository.saveAll(List.of(equipmentRentalSpec));
+		final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservation1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.build();
+		rentalSpecRepository.saveAll(List.of(equipmentRentalSpec));
 
-        final Long memberId = 1L;
-        final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(memberId).reservationId(reservation1.getId()).rentalSpecId(reservationSpec1.getId())
-                .reservationSpecId(reservationSpec1.getId()).period(PenaltyPeriod.fromPenaltyCount(0)).build());
+		final Long memberId = 1L;
+		final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN)
+			.memberId(memberId)
+			.reservationId(reservation1.getId())
+			.rentalSpecId(reservationSpec1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(0))
+			.build());
 
-        final UpdatePeriodRequest requestBody = new UpdatePeriodRequest(PenaltyStatus.ONE_YEAR);
+		final UpdatePeriodRequest requestBody = new UpdatePeriodRequest(PenaltyStatus.ONE_YEAR);
 
-        // when
-        RestAssured.given(requestSpec)
-                .filter(document("updatePenaltyPeriod"))
-                .contentType(ContentType.JSON)
-                .body(requestBody)
-                .when().log().all().patch("/api/admin/penalties/{id}", penalty1.getId())
-                .then().log().all()
-                .statusCode(HttpStatus.NO_CONTENT.value());
+		// when
+		RestAssured.given(requestSpec)
+			.filter(document("updatePenaltyPeriod"))
+			.contentType(ContentType.JSON)
+			.body(requestBody)
+			.when().log().all().patch("/api/admin/penalties/{id}", penalty1.getId())
+			.then().log().all()
+			.statusCode(HttpStatus.NO_CONTENT.value());
 
-        // then
-        final Penalty actual = penaltyRepository.findById(penalty1.getId()).orElseThrow();
-        assertThat(actual.getPeriod().getStatus()).isEqualTo(PenaltyStatus.ONE_YEAR);
-    }
+		// then
+		final Penalty actual = penaltyRepository.findById(penalty1.getId()).orElseThrow();
+		assertThat(actual.getPeriod().getStatus()).isEqualTo(PenaltyStatus.ONE_YEAR);
+	}
 
-    @Test
-    @DisplayName("패널티를 삭제한다..")
-    void deletePenalty() {
-        // given
-        final Rentable equipment = assetRepository.save(EquipmentFixture.create());
+	@Test
+	@DisplayName("패널티를 삭제한다..")
+	void deletePenalty() {
+		// given
+		final Rentable equipment = assetRepository.save(EquipmentFixture.create());
 
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
-        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1)));
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
+		final Reservation reservation1 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec1)));
 
-        final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder().reservationId(reservation1.getId()).reservationSpecId(reservationSpec1.getId()).build();
-        rentalSpecRepository.saveAll(List.of(equipmentRentalSpec));
+		final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservation1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.build();
+		rentalSpecRepository.saveAll(List.of(equipmentRentalSpec));
 
-        final Long memberId = 1L;
-        final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(memberId).reservationId(reservation1.getId()).rentalSpecId(reservationSpec1.getId())
-                .reservationSpecId(reservationSpec1.getId()).period(PenaltyPeriod.fromPenaltyCount(0)).build());
+		final Long memberId = 1L;
+		final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN)
+			.memberId(memberId)
+			.reservationId(reservation1.getId())
+			.rentalSpecId(reservationSpec1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(0))
+			.build());
 
-        // when
-        RestAssured.given(requestSpec)
-                .filter(document("deletePenalty"))
-                .when().log().all().delete("/api/admin/penalties/{id}", penalty1.getId())
-                .then().log().all()
-                .statusCode(HttpStatus.NO_CONTENT.value());
+		// when
+		RestAssured.given(requestSpec)
+			.filter(document("deletePenalty"))
+			.when().log().all().delete("/api/admin/penalties/{id}", penalty1.getId())
+			.then().log().all()
+			.statusCode(HttpStatus.NO_CONTENT.value());
 
-        // then
-        final Optional<Penalty> actual = penaltyRepository.findById(penalty1.getId());
-        assertThat(actual).isEqualTo(Optional.empty());
-    }
+		// then
+		final Optional<Penalty> actual = penaltyRepository.findById(penalty1.getId());
+		assertThat(actual).isEqualTo(Optional.empty());
+	}
 }

--- a/src/test/java/com/girigiri/kwrental/penalty/repository/PenaltyRepositoryTest.java
+++ b/src/test/java/com/girigiri/kwrental/penalty/repository/PenaltyRepositoryTest.java
@@ -1,8 +1,22 @@
 package com.girigiri.kwrental.penalty.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
 import com.girigiri.kwrental.asset.domain.Rentable;
 import com.girigiri.kwrental.asset.repository.AssetRepository;
 import com.girigiri.kwrental.config.JpaConfig;
+import com.girigiri.kwrental.inventory.domain.RentalDateTime;
 import com.girigiri.kwrental.penalty.domain.Penalty;
 import com.girigiri.kwrental.penalty.domain.PenaltyPeriod;
 import com.girigiri.kwrental.penalty.domain.PenaltyReason;
@@ -15,114 +29,153 @@ import com.girigiri.kwrental.rental.repository.RentalSpecRepository;
 import com.girigiri.kwrental.reservation.domain.Reservation;
 import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.repository.ReservationRepository;
-import com.girigiri.kwrental.testsupport.fixture.*;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-
-import java.time.LocalDate;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
+import com.girigiri.kwrental.testsupport.fixture.EquipmentRentalSpecFixture;
+import com.girigiri.kwrental.testsupport.fixture.LabRoomFixture;
+import com.girigiri.kwrental.testsupport.fixture.LabRoomRentalSpecFixture;
+import com.girigiri.kwrental.testsupport.fixture.PenaltyFixture;
+import com.girigiri.kwrental.testsupport.fixture.ReservationFixture;
+import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
 
 @DataJpaTest
 @Import(JpaConfig.class)
 class PenaltyRepositoryTest {
 
-    @Autowired
-    private PenaltyRepository penaltyRepository;
-    @Autowired
-    private AssetRepository assetRepository;
-    @Autowired
-    private ReservationRepository reservationRepository;
-    @Autowired
-    private RentalSpecRepository rentalSpecRepository;
+	@Autowired
+	private PenaltyRepository penaltyRepository;
+	@Autowired
+	private AssetRepository assetRepository;
+	@Autowired
+	private ReservationRepository reservationRepository;
+	@Autowired
+	private RentalSpecRepository rentalSpecRepository;
 
-    @Test
-    @DisplayName("특정 회원의 현재 진행 중인 페널티를 조회한다.")
-    void findOngoingPenalty() {
-        // given
-        final LocalDate now = LocalDate.now();
-        final PenaltyPeriod penaltyPeriod1 = new PenaltyPeriod(now, now.plusDays(3));
-        final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(1L).period(penaltyPeriod1).build());
-        final PenaltyPeriod penaltyPeriod2 = new PenaltyPeriod(now.minusDays(2), now.minusDays(1));
-        final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(1L).period(penaltyPeriod2).build());
-        final PenaltyPeriod penaltyPeriod3 = new PenaltyPeriod(now.minusDays(2), now);
-        final Penalty penalty3 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(1L).period(penaltyPeriod3).build());
-        final Penalty penalty4 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(2L).period(penaltyPeriod1).build());
+	@Test
+	@DisplayName("특정 회원의 현재 진행 중인 페널티를 조회한다.")
+	void findOngoingPenalty() {
+		// given
+		final LocalDate now = LocalDate.now();
+		final PenaltyPeriod penaltyPeriod1 = new PenaltyPeriod(now, now.plusDays(3));
+		final Penalty penalty1 = penaltyRepository.save(
+			PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(1L).period(penaltyPeriod1).build());
+		final PenaltyPeriod penaltyPeriod2 = new PenaltyPeriod(now.minusDays(2), now.minusDays(1));
+		final Penalty penalty2 = penaltyRepository.save(
+			PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(1L).period(penaltyPeriod2).build());
+		final PenaltyPeriod penaltyPeriod3 = new PenaltyPeriod(now.minusDays(2), now);
+		final Penalty penalty3 = penaltyRepository.save(
+			PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(1L).period(penaltyPeriod3).build());
+		final Penalty penalty4 = penaltyRepository.save(
+			PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(2L).period(penaltyPeriod1).build());
 
-        // when
-        final List<Penalty> actual = penaltyRepository.findByOngoingPenalties(1L);
+		// when
+		final List<Penalty> actual = penaltyRepository.findByOngoingPenalties(1L);
 
-        // then
-        assertThat(actual).containsExactlyInAnyOrder(penalty1, penalty3);
-    }
+		// then
+		assertThat(actual).containsExactlyInAnyOrder(penalty1, penalty3);
+	}
 
-    @Test
-    @DisplayName("특정 회원의 페널티 이력을 조회한다.")
-    void findUserPenaltiesResponseByMemberId() {
-        // given
-        final Rentable equipment = assetRepository.save(EquipmentFixture.create());
-        final Rentable labRoom = assetRepository.save(LabRoomFixture.create());
+	@Test
+	@DisplayName("특정 회원의 페널티 이력을 조회한다.")
+	void findUserPenaltiesResponseByMemberId() {
+		// given
+		final Rentable equipment = assetRepository.save(EquipmentFixture.create());
+		final Rentable labRoom = assetRepository.save(LabRoomFixture.create());
 
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
-        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1)));
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.create(labRoom);
-        final Reservation reservation2 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec2)));
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
+		final Reservation reservation1 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec1)));
+		final ReservationSpec reservationSpec2 = ReservationSpecFixture.create(labRoom);
+		final Reservation reservation2 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec2)));
 
-        final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder().reservationId(reservation1.getId()).reservationSpecId(reservationSpec1.getId()).build();
-        final LabRoomRentalSpec labRoomRentalSpec = LabRoomRentalSpecFixture.builder().reservationId(reservation2.getId()).reservationSpecId(reservationSpec2.getId()).build();
-        rentalSpecRepository.saveAll(List.of(equipmentRentalSpec, labRoomRentalSpec));
+		final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservation1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.returnDateTime(RentalDateTime.now())
+			.build();
+		final LabRoomRentalSpec labRoomRentalSpec = LabRoomRentalSpecFixture.builder()
+			.reservationId(reservation2.getId())
+			.reservationSpecId(reservationSpec2.getId())
+			.build();
+		rentalSpecRepository.saveAll(List.of(equipmentRentalSpec, labRoomRentalSpec));
 
-        final Long memberId = 1L;
-        final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(memberId).reservationId(reservation1.getId()).rentalSpecId(reservationSpec1.getId())
-                .reservationSpecId(reservationSpec1.getId()).period(PenaltyPeriod.fromPenaltyCount(0)).build());
-        final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.LOST).memberId(0L).reservationId(reservation2.getId()).rentalSpecId(reservationSpec2.getId())
-                .reservationSpecId(reservationSpec2.getId()).period(PenaltyPeriod.fromPenaltyCount(1)).build());
+		final Long memberId = 1L;
+		final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN)
+			.memberId(memberId)
+			.reservationId(reservation1.getId())
+			.rentalSpecId(equipmentRentalSpec.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(0))
+			.build());
+		final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.LOST)
+			.memberId(0L)
+			.reservationId(reservation2.getId())
+			.rentalSpecId(labRoomRentalSpec.getId())
+			.reservationSpecId(reservationSpec2.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(1))
+			.build());
 
-        // when
-        final UserPenaltiesResponse actual = penaltyRepository.findUserPenaltiesResponseByMemberId(memberId);
+		// when
+		final UserPenaltiesResponse actual = penaltyRepository.findUserPenaltiesResponseByMemberId(memberId);
 
-        // then
-        assertThat(actual.getPenalties()).usingRecursiveFieldByFieldElementComparator()
-                .containsExactly(
-                        new UserPenaltyResponse(penalty1.getId(), penalty1.getPeriod(), equipment.getName(), penalty1.getReason())
-                );
-    }
+		// then
+		assertThat(actual.getPenalties()).usingRecursiveFieldByFieldElementComparator()
+			.containsExactly(
+				new UserPenaltyResponse(penalty1.getId(), equipmentRentalSpec.getAcceptDateTime().toLocalDate(),
+					equipmentRentalSpec.getReturnDateTime().toLocalDate(), penalty1.getStatusMessage(),
+					equipment.getName(), penalty1.getReason())
+			);
+	}
 
-    @Test
-    @DisplayName("페널티 히스토리를 조회한다.")
-    void findPenaltyHistoryPageResponse() {
-        // given
-        final Rentable equipment = assetRepository.save(EquipmentFixture.create());
-        final Rentable labRoom = assetRepository.save(LabRoomFixture.create());
+	@Test
+	@DisplayName("페널티 히스토리를 조회한다.")
+	void findPenaltyHistoryPageResponse() {
+		// given
+		final Rentable equipment = assetRepository.save(EquipmentFixture.create());
+		final Rentable labRoom = assetRepository.save(LabRoomFixture.create());
 
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
-        final Reservation reservation1 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec1)));
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.create(labRoom);
-        final Reservation reservation2 = reservationRepository.save(ReservationFixture.create(List.of(reservationSpec2)));
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.create(equipment);
+		final Reservation reservation1 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec1)));
+		final ReservationSpec reservationSpec2 = ReservationSpecFixture.create(labRoom);
+		final Reservation reservation2 = reservationRepository.save(
+			ReservationFixture.create(List.of(reservationSpec2)));
 
-        final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder().reservationId(reservation1.getId()).reservationSpecId(reservationSpec1.getId()).build();
-        final LabRoomRentalSpec labRoomRentalSpec = LabRoomRentalSpecFixture.builder().reservationId(reservation2.getId()).reservationSpecId(reservationSpec2.getId()).build();
-        rentalSpecRepository.saveAll(List.of(equipmentRentalSpec, labRoomRentalSpec));
+		final EquipmentRentalSpec equipmentRentalSpec = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservation1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.build();
+		final LabRoomRentalSpec labRoomRentalSpec = LabRoomRentalSpecFixture.builder()
+			.reservationId(reservation2.getId())
+			.reservationSpecId(reservationSpec2.getId())
+			.build();
+		rentalSpecRepository.saveAll(List.of(equipmentRentalSpec, labRoomRentalSpec));
 
-        final Long memberId = 1L;
-        final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN).memberId(memberId).reservationId(reservation1.getId()).rentalSpecId(reservationSpec1.getId())
-                .reservationSpecId(reservationSpec1.getId()).period(PenaltyPeriod.fromPenaltyCount(0)).build());
-        final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.LOST).memberId(0L).reservationId(reservation2.getId()).rentalSpecId(reservationSpec2.getId())
-                .reservationSpecId(reservationSpec2.getId()).period(PenaltyPeriod.fromPenaltyCount(1)).build());
+		final Long memberId = 1L;
+		final Penalty penalty1 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.BROKEN)
+			.memberId(memberId)
+			.reservationId(reservation1.getId())
+			.rentalSpecId(reservationSpec1.getId())
+			.reservationSpecId(reservationSpec1.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(0))
+			.build());
+		final Penalty penalty2 = penaltyRepository.save(PenaltyFixture.builder(PenaltyReason.LOST)
+			.memberId(0L)
+			.reservationId(reservation2.getId())
+			.rentalSpecId(reservationSpec2.getId())
+			.reservationSpecId(reservationSpec2.getId())
+			.period(PenaltyPeriod.fromPenaltyCount(1))
+			.build());
 
-        // when
-        final Page<PenaltyHistoryResponse> actual = penaltyRepository.findPenaltyHistoryPageResponse(PageRequest.of(0, 1));
+		// when
+		final Page<PenaltyHistoryResponse> actual = penaltyRepository.findPenaltyHistoryPageResponse(
+			PageRequest.of(0, 1));
 
-        // then
-        assertThat(actual.getContent()).usingRecursiveFieldByFieldElementComparator()
-                .containsExactly(
-                        new PenaltyHistoryResponse(penalty1.getId(), reservation1.getName(), penalty1.getPeriod(), equipment.getName(), penalty1.getReason()));
-        assertThat(actual.getTotalElements()).isEqualTo(2);
-    }
+		// then
+		assertThat(actual.getContent()).usingRecursiveFieldByFieldElementComparator()
+			.containsExactly(
+				new PenaltyHistoryResponse(penalty1.getId(), reservation1.getName(), penalty1.getPeriod(),
+					equipment.getName(), penalty1.getReason()));
+		assertThat(actual.getTotalElements()).isEqualTo(2);
+	}
 }

--- a/src/test/java/com/girigiri/kwrental/rental/service/RentalServiceTest.java
+++ b/src/test/java/com/girigiri/kwrental/rental/service/RentalServiceTest.java
@@ -43,6 +43,7 @@ import com.girigiri.kwrental.reservation.domain.ReservationSpec;
 import com.girigiri.kwrental.reservation.domain.ReservationSpecStatus;
 import com.girigiri.kwrental.reservation.service.PenaltyService;
 import com.girigiri.kwrental.reservation.service.ReservationService;
+import com.girigiri.kwrental.testsupport.DeepReflectionEqMatcher;
 import com.girigiri.kwrental.testsupport.fixture.EquipmentFixture;
 import com.girigiri.kwrental.testsupport.fixture.EquipmentRentalSpecFixture;
 import com.girigiri.kwrental.testsupport.fixture.ReservationFixture;
@@ -51,235 +52,355 @@ import com.girigiri.kwrental.testsupport.fixture.ReservationSpecFixture;
 @ExtendWith(MockitoExtension.class)
 class RentalServiceTest {
 
-    private final ArgumentCaptor<List<EquipmentRentalSpec>> rentalSpecListArgumentCaptor = ArgumentCaptor.forClass(List.class);
+	private final ArgumentCaptor<List<EquipmentRentalSpec>> rentalSpecListArgumentCaptor = ArgumentCaptor.forClass(
+		List.class);
 
-    @Mock
-    private ItemService itemService;
-    @Mock
-    private ReservationService reservationService;
-    @Mock
-    private RentalSpecRepository rentalSpecRepository;
-    @Mock
-    private PenaltyService penaltyService;
+	@Mock
+	private ItemService itemService;
+	@Mock
+	private ReservationService reservationService;
+	@Mock
+	private RentalSpecRepository rentalSpecRepository;
+	@Mock
+	private PenaltyService penaltyService;
 
-    @InjectMocks
-    private RentalService rentalService;
+	@InjectMocks
+	private RentalService rentalService;
 
+	@Test
+	@DisplayName("대여를 생성할 때 이미 대여 중인 품목으로 대여하려면 예외 발생")
+	void rent_duplicateRental() {
+		// given
+		final Long reservationId = 1L;
+		final String propertyNumber = "12345678";
+		final Long reservationSpecId = 2L;
+		final CreateRentalRequest request = new CreateRentalRequest(
+			reservationId, List.of(new RentalSpecsRequest(reservationSpecId, List.of(propertyNumber)))
+		);
+		given(reservationService.validatePropertyNumbersCountAndGroupByEquipmentId(any(), any()))
+			.willReturn(Map.of(1L, Set.of(propertyNumber)));
+		doNothing().when(itemService).validatePropertyNumbers(any());
+		given(rentalSpecRepository.findByPropertyNumbers(any()))
+			.willReturn(
+				List.of(EquipmentRentalSpecFixture.builder().id(1L).reservationSpecId(reservationSpecId).build()));
 
-    @Test
-    @DisplayName("대여를 생성할 때 이미 대여 중인 품목으로 대여하려면 예외 발생")
-    void rent_duplicateRental() {
-        // given
-        final Long reservationId = 1L;
-        final String propertyNumber = "12345678";
-        final Long reservationSpecId = 2L;
-        final CreateRentalRequest request = new CreateRentalRequest(
-                reservationId, List.of(new RentalSpecsRequest(reservationSpecId, List.of(propertyNumber)))
-        );
-        given(reservationService.validatePropertyNumbersCountAndGroupByEquipmentId(any(), any()))
-                .willReturn(Map.of(1L, Set.of(propertyNumber)));
-        doNothing().when(itemService).validatePropertyNumbers(any());
-        given(rentalSpecRepository.findByPropertyNumbers(any()))
-                .willReturn(List.of(EquipmentRentalSpecFixture.builder().id(1L).reservationSpecId(reservationSpecId).build()));
+		// when, then
+		assertThatThrownBy(() -> rentalService.rent(request))
+			.isExactlyInstanceOf(DuplicateRentalException.class);
+	}
 
-        // when, then
-        assertThatThrownBy(() -> rentalService.rent(request))
-                .isExactlyInstanceOf(DuplicateRentalException.class);
-    }
+	@Test
+	@DisplayName("대여를 생성한다.")
+	void rent() {
+		// given
+		final Long reservationId = 1L;
+		final String propertyNumber = "12345678";
+		final Long reservationSpecId = 2L;
+		final CreateRentalRequest request = new CreateRentalRequest(
+			reservationId, List.of(new RentalSpecsRequest(reservationSpecId, List.of(propertyNumber)))
+		);
+		given(reservationService.validatePropertyNumbersCountAndGroupByEquipmentId(any(), any()))
+			.willReturn(Map.of(1L, Set.of(propertyNumber)));
+		doNothing().when(itemService).validatePropertyNumbers(any());
+		given(rentalSpecRepository.findByPropertyNumbers(any()))
+			.willReturn(Collections.emptyList());
+		final List<EquipmentRentalSpec> output = List.of(
+			EquipmentRentalSpecFixture.builder().reservationId(reservationId)
+				.propertyNumber(propertyNumber).reservationSpecId(reservationSpecId).id(1L).build());
+		final EquipmentRentalSpec expect = EquipmentRentalSpecFixture.builder().reservationId(reservationId)
+			.propertyNumber(propertyNumber).reservationSpecId(reservationSpecId).build();
+		given(rentalSpecRepository.saveAll(DeepReflectionEqMatcher.deepRefEq(List.of(expect), "acceptDateTime")))
+			.willReturn(output);
 
-    @Test
-    @DisplayName("대여를 생성한다.")
-    void rent() {
-        // given
-        final Long reservationId = 1L;
-        final String propertyNumber = "12345678";
-        final Long reservationSpecId = 2L;
-        final CreateRentalRequest request = new CreateRentalRequest(
-                reservationId, List.of(new RentalSpecsRequest(reservationSpecId, List.of(propertyNumber)))
-        );
-        given(reservationService.validatePropertyNumbersCountAndGroupByEquipmentId(any(), any()))
-                .willReturn(Map.of(1L, Set.of(propertyNumber)));
-        doNothing().when(itemService).validatePropertyNumbers(any());
-        given(rentalSpecRepository.findByPropertyNumbers(any()))
-                .willReturn(Collections.emptyList());
-        final List<EquipmentRentalSpec> output = List.of(EquipmentRentalSpecFixture.builder().reservationId(reservationId)
-                .propertyNumber(propertyNumber).reservationSpecId(reservationSpecId).id(1L).build());
-        given(rentalSpecRepository.saveAll(rentalSpecListArgumentCaptor.capture()))
-                .willReturn(output);
+		// when, then
+		assertThatCode(() -> rentalService.rent(request))
+			.doesNotThrowAnyException();
+	}
 
-        // when, then
-        final EquipmentRentalSpec expect = EquipmentRentalSpecFixture.builder().reservationId(reservationId)
-                .propertyNumber(propertyNumber).reservationSpecId(reservationSpecId).acceptDateTime(null).build();
-        assertAll(
-                () -> assertThatCode(() -> rentalService.rent(request))
-                        .doesNotThrowAnyException(),
-                () -> assertThat(rentalSpecListArgumentCaptor.getValue())
-                        .usingRecursiveFieldByFieldElementComparator().containsExactly(expect)
-        );
-    }
+	@Test
+	@DisplayName("특정 날짜가 대여 수령일인 대여 예약을 대여 수령 시간과 대여 상세를 함께 조회한다.")
+	void getReservationsWithRentalSpecsByStartDate() {
+		// given
+		final Equipment equipment1 = EquipmentFixture.create();
+		final Equipment equipment2 = EquipmentFixture.create();
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment1)
+			.id(1L)
+			.status(ReservationSpecStatus.RESERVED)
+			.build();
+		final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment2)
+			.id(2L)
+			.status(ReservationSpecStatus.CANCELED)
+			.build();
+		final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2))
+			.id(1L)
+			.acceptDateTime(RentalDateTime.now())
+			.build();
+		final EquipmentRentalSpec rentalSpec1 = EquipmentRentalSpecFixture.builder()
+			.reservationSpecId(reservationSpec1.getId())
+			.build();
+		final EquipmentReservationWithMemberNumber equipmentReservation = EquipmentReservationWithMemberNumber.of(
+			reservation, List.of(reservationSpec1), "11111111");
+		given(reservationService.getReservationsByStartDate(any())).willReturn(Set.of(equipmentReservation));
+		given(rentalSpecRepository.findByReservationSpecIds(Set.of(reservationSpec1.getId()))).willReturn(
+			List.of(rentalSpec1));
 
-    @Test
-    @DisplayName("특정 날짜가 대여 수령일인 대여 예약을 대여 수령 시간과 대여 상세를 함께 조회한다.")
-    void getReservationsWithRentalSpecsByStartDate() {
-        // given
-        final Equipment equipment1 = EquipmentFixture.create();
-        final Equipment equipment2 = EquipmentFixture.create();
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(equipment1).id(1L).status(ReservationSpecStatus.RESERVED).build();
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(equipment2).id(2L).status(ReservationSpecStatus.CANCELED).build();
-        final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).id(1L).acceptDateTime(RentalDateTime.now()).build();
-        final EquipmentRentalSpec rentalSpec1 = EquipmentRentalSpecFixture.builder().reservationSpecId(reservationSpec1.getId()).build();
-        final EquipmentReservationWithMemberNumber equipmentReservation = EquipmentReservationWithMemberNumber.of(reservation, List.of(reservationSpec1), "11111111");
-        given(reservationService.getReservationsByStartDate(any())).willReturn(Set.of(equipmentReservation));
-        given(rentalSpecRepository.findByReservationSpecIds(Set.of(reservationSpec1.getId()))).willReturn(List.of(rentalSpec1));
+		// when
+		final EquipmentReservationsWithRentalSpecsResponse response = rentalService.getReservationsWithRentalSpecsByStartDate(
+			LocalDate.now());
 
-        // when
-        final EquipmentReservationsWithRentalSpecsResponse response = rentalService.getReservationsWithRentalSpecsByStartDate(LocalDate.now());
+		assertThat(response.getReservations()).usingRecursiveFieldByFieldElementComparator()
+			.containsExactly(
+				EquipmentReservationWithRentalSpecsResponse.of(equipmentReservation, List.of(rentalSpec1)));
+		assertThat(
+			response.getReservations().get(0).getReservationSpecs()).usingRecursiveFieldByFieldElementComparator()
+			.containsExactly(ReservationSpecWithRentalSpecsResponse.of(reservationSpec1, List.of(rentalSpec1)));
+	}
 
-        assertThat(response.getReservations()).usingRecursiveFieldByFieldElementComparator()
-                .containsExactly(EquipmentReservationWithRentalSpecsResponse.of(equipmentReservation, List.of(rentalSpec1)));
-        assertThat(response.getReservations().get(0).getReservationSpecs()).usingRecursiveFieldByFieldElementComparator().containsExactly(ReservationSpecWithRentalSpecsResponse.of(reservationSpec1, List.of(rentalSpec1)));
-    }
+	@Test
+	@DisplayName("연체중과 불량 반납을 포함하여 대여를 반납한다.")
+	void returnRental() {
+		// given
+		final long reservationId = 1L;
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null)
+			.period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now()))
+			.amount(RentalAmount.ofPositive(1))
+			.id(1L)
+			.build();
+		final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null)
+			.period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now()))
+			.amount(RentalAmount.ofPositive(2))
+			.id(2L)
+			.build();
+		final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(null)
+			.period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now()))
+			.amount(RentalAmount.ofPositive(1))
+			.id(3L)
+			.build();
+		final Reservation reservation = ReservationFixture.builder(
+			List.of(reservationSpec1, reservationSpec2, reservationSpec3)).id(reservationId).build();
+		given(reservationService.getReservationWithReservationSpecsById(reservationId)).willReturn(reservation);
 
-    @Test
-    @DisplayName("연체중과 불량 반납을 포함하여 대여를 반납한다.")
-    void returnRental() {
-        // given
-        final long reservationId = 1L;
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(RentalAmount.ofPositive(1)).id(1L).build();
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(RentalAmount.ofPositive(2)).id(2L).build();
-        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(null).period(new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now())).amount(RentalAmount.ofPositive(1)).id(3L).build();
-        final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2, reservationSpec3)).id(reservationId).build();
-        given(reservationService.getReservationWithReservationSpecsById(reservationId)).willReturn(reservation);
+		final ReturnRentalSpecRequest rentalSpecRequest1 = ReturnRentalSpecRequest.builder()
+			.id(2L)
+			.status(RentalSpecStatus.RETURNED)
+			.build();
+		final ReturnRentalSpecRequest rentalSpecRequest2 = ReturnRentalSpecRequest.builder()
+			.id(3L)
+			.status(RentalSpecStatus.LOST)
+			.build();
+		final ReturnRentalSpecRequest rentalSpecRequest3 = ReturnRentalSpecRequest.builder()
+			.id(4L)
+			.status(RentalSpecStatus.OVERDUE_RENTED)
+			.build();
+		final ReturnRentalSpecRequest rentalSpecRequest4 = ReturnRentalSpecRequest.builder()
+			.id(5L)
+			.status(RentalSpecStatus.BROKEN)
+			.build();
+		final ReturnRentalRequest returnReturnRequest = ReturnRentalRequest.builder()
+			.reservationId(reservationId)
+			.rentalSpecs(List.of(rentalSpecRequest1, rentalSpecRequest2, rentalSpecRequest3, rentalSpecRequest4))
+			.build();
 
-        final ReturnRentalSpecRequest rentalSpecRequest1 = ReturnRentalSpecRequest.builder().id(2L).status(RentalSpecStatus.RETURNED).build();
-        final ReturnRentalSpecRequest rentalSpecRequest2 = ReturnRentalSpecRequest.builder().id(3L).status(RentalSpecStatus.LOST).build();
-        final ReturnRentalSpecRequest rentalSpecRequest3 = ReturnRentalSpecRequest.builder().id(4L).status(RentalSpecStatus.OVERDUE_RENTED).build();
-        final ReturnRentalSpecRequest rentalSpecRequest4 = ReturnRentalSpecRequest.builder().id(5L).status(RentalSpecStatus.BROKEN).build();
-        final ReturnRentalRequest returnReturnRequest = ReturnRentalRequest.builder()
-                .reservationId(reservationId)
-                .rentalSpecs(List.of(rentalSpecRequest1, rentalSpecRequest2, rentalSpecRequest3, rentalSpecRequest4)).build();
+		final EquipmentRentalSpec rentalSpec1 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec1.getId())
+			.id(rentalSpecRequest1.getId())
+			.propertyNumber("11111111")
+			.build();
+		final EquipmentRentalSpec rentalSpec2 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec2.getId())
+			.id(rentalSpecRequest2.getId())
+			.propertyNumber("22222222")
+			.build();
+		final EquipmentRentalSpec rentalSpec3 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec2.getId())
+			.id(rentalSpecRequest3.getId())
+			.propertyNumber("33333333")
+			.build();
+		final EquipmentRentalSpec rentalSpec4 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec3.getId())
+			.id(rentalSpecRequest4.getId())
+			.propertyNumber("44444444")
+			.build();
 
-        final EquipmentRentalSpec rentalSpec1 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec1.getId())
-                .id(rentalSpecRequest1.getId()).propertyNumber("11111111").build();
-        final EquipmentRentalSpec rentalSpec2 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec2.getId())
-                .id(rentalSpecRequest2.getId()).propertyNumber("22222222").build();
-        final EquipmentRentalSpec rentalSpec3 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec2.getId())
-                .id(rentalSpecRequest3.getId()).propertyNumber("33333333").build();
-        final EquipmentRentalSpec rentalSpec4 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec3.getId())
-                .id(rentalSpecRequest4.getId()).propertyNumber("44444444").build();
+		given(rentalSpecRepository.findByReservationId(reservationId)).willReturn(
+			List.of(rentalSpec1, rentalSpec2, rentalSpec3, rentalSpec4));
 
-        given(rentalSpecRepository.findByReservationId(reservationId)).willReturn(List.of(rentalSpec1, rentalSpec2, rentalSpec3, rentalSpec4));
+		doNothing().when(itemService).setAvailable(rentalSpec2.getPropertyNumber(), false);
+		doNothing().when(penaltyService)
+			.createOrUpdate(reservation.getMemberId(), reservationId, rentalSpec2.getReservationSpecId(),
+				rentalSpec2.getId(), RentalSpecStatus.LOST);
+		doNothing().when(itemService).setAvailable(rentalSpec3.getPropertyNumber(), false);
+		doNothing().when(penaltyService)
+			.createOrUpdate(reservation.getMemberId(), reservationId, rentalSpec3.getReservationSpecId(),
+				rentalSpec3.getId(), RentalSpecStatus.OVERDUE_RENTED);
+		doNothing().when(itemService).setAvailable(rentalSpec4.getPropertyNumber(), false);
+		doNothing().when(penaltyService)
+			.createOrUpdate(reservation.getMemberId(), reservationId, rentalSpec4.getReservationSpecId(),
+				rentalSpec4.getId(), RentalSpecStatus.BROKEN);
 
-        doNothing().when(itemService).setAvailable(rentalSpec2.getPropertyNumber(), false);
-        doNothing().when(penaltyService)
-            .createOrUpdate(reservation.getMemberId(), reservationId, rentalSpec2.getReservationSpecId(),
-                rentalSpec2.getId(), RentalSpecStatus.LOST);
-        doNothing().when(itemService).setAvailable(rentalSpec3.getPropertyNumber(), false);
-        doNothing().when(penaltyService)
-            .createOrUpdate(reservation.getMemberId(), reservationId, rentalSpec3.getReservationSpecId(),
-                rentalSpec3.getId(), RentalSpecStatus.OVERDUE_RENTED);
-        doNothing().when(itemService).setAvailable(rentalSpec4.getPropertyNumber(), false);
-        doNothing().when(penaltyService)
-            .createOrUpdate(reservation.getMemberId(), reservationId, rentalSpec4.getReservationSpecId(),
-                rentalSpec4.getId(), RentalSpecStatus.BROKEN);
+		// when
+		assertThatCode(() -> rentalService.returnRental(returnReturnRequest))
+			.doesNotThrowAnyException();
 
-        // when
-        assertThatCode(() -> rentalService.returnRental(returnReturnRequest))
-                .doesNotThrowAnyException();
+		// then
+		assertAll(
+			() -> assertThat(reservation.isTerminated()).isFalse(),
+			() -> assertThat(rentalSpec1.getStatus()).isEqualTo(RentalSpecStatus.RETURNED),
+			() -> assertThat(rentalSpec2.getStatus()).isEqualTo(RentalSpecStatus.LOST),
+			() -> assertThat(rentalSpec3.getStatus()).isEqualTo(RentalSpecStatus.OVERDUE_RENTED),
+			() -> assertThat(rentalSpec4.getStatus()).isEqualTo(RentalSpecStatus.BROKEN),
+			() -> assertThat(reservationSpec1.getStatus()).isEqualTo(ReservationSpecStatus.RETURNED),
+			() -> assertThat(reservationSpec2.getStatus()).isEqualTo(ReservationSpecStatus.OVERDUE_RENTED)
+		);
+	}
 
-        // then
-        assertAll(
-                () -> assertThat(reservation.isTerminated()).isFalse(),
-                () -> assertThat(rentalSpec1.getStatus()).isEqualTo(RentalSpecStatus.RETURNED),
-                () -> assertThat(rentalSpec2.getStatus()).isEqualTo(RentalSpecStatus.LOST),
-                () -> assertThat(rentalSpec3.getStatus()).isEqualTo(RentalSpecStatus.OVERDUE_RENTED),
-                () -> assertThat(rentalSpec4.getStatus()).isEqualTo(RentalSpecStatus.BROKEN),
-                () -> assertThat(reservationSpec1.getStatus()).isEqualTo(ReservationSpecStatus.RETURNED),
-                () -> assertThat(reservationSpec2.getStatus()).isEqualTo(ReservationSpecStatus.OVERDUE_RENTED)
-        );
-    }
+	@Test
+	@DisplayName("연체 반납을 포함하여 반납한다.")
+	void returnRental_withOverdueReturned() {
+		// given
+		final long reservationId = 1L;
+		final RentalPeriod overduePeriod = new RentalPeriod(LocalDate.now().minusDays(2), LocalDate.now().minusDays(1));
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null)
+			.status(ReservationSpecStatus.RETURNED)
+			.period(overduePeriod)
+			.amount(RentalAmount.ofPositive(1))
+			.id(1L)
+			.build();
+		final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null)
+			.status(ReservationSpecStatus.OVERDUE_RENTED)
+			.period(overduePeriod)
+			.amount(RentalAmount.ofPositive(2))
+			.id(2L)
+			.build();
+		final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(null)
+			.status(ReservationSpecStatus.ABNORMAL_RETURNED)
+			.period(overduePeriod)
+			.amount(RentalAmount.ofPositive(1))
+			.id(3L)
+			.build();
+		final Reservation reservation = ReservationFixture.builder(
+			List.of(reservationSpec1, reservationSpec2, reservationSpec3)).id(reservationId).build();
+		given(reservationService.getReservationWithReservationSpecsById(reservationId)).willReturn(reservation);
 
-    @Test
-    @DisplayName("연체 반납을 포함하여 반납한다.")
-    void returnRental_withOverdueReturned() {
-        // given
-        final long reservationId = 1L;
-        final RentalPeriod overduePeriod = new RentalPeriod(LocalDate.now().minusDays(2), LocalDate.now().minusDays(1));
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null).status(ReservationSpecStatus.RETURNED)
-                .period(overduePeriod).amount(RentalAmount.ofPositive(1)).id(1L).build();
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null).status(ReservationSpecStatus.OVERDUE_RENTED)
-                .period(overduePeriod).amount(RentalAmount.ofPositive(2)).id(2L).build();
-        final ReservationSpec reservationSpec3 = ReservationSpecFixture.builder(null).status(ReservationSpecStatus.ABNORMAL_RETURNED)
-                .period(overduePeriod).amount(RentalAmount.ofPositive(1)).id(3L).build();
-        final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2, reservationSpec3)).id(reservationId).build();
-        given(reservationService.getReservationWithReservationSpecsById(reservationId)).willReturn(reservation);
+		final ReturnRentalSpecRequest rentalSpecRequest3 = ReturnRentalSpecRequest.builder()
+			.id(4L)
+			.status(RentalSpecStatus.RETURNED)
+			.build();
+		final ReturnRentalRequest returnReturnRequest = ReturnRentalRequest.builder()
+			.reservationId(reservationId)
+			.rentalSpecs(List.of(rentalSpecRequest3)).build();
 
-        final ReturnRentalSpecRequest rentalSpecRequest3 = ReturnRentalSpecRequest.builder().id(4L).status(RentalSpecStatus.RETURNED).build();
-        final ReturnRentalRequest returnReturnRequest = ReturnRentalRequest.builder()
-                .reservationId(reservationId)
-                .rentalSpecs(List.of(rentalSpecRequest3)).build();
+		final EquipmentRentalSpec rentalSpec1 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec1.getId())
+			.status(RentalSpecStatus.RETURNED)
+			.id(2L)
+			.propertyNumber("11111111")
+			.build();
+		final EquipmentRentalSpec rentalSpec2 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec2.getId())
+			.status(RentalSpecStatus.LOST)
+			.id(3L)
+			.propertyNumber("22222222")
+			.build();
+		final EquipmentRentalSpec rentalSpec3 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec2.getId())
+			.status(RentalSpecStatus.OVERDUE_RENTED)
+			.id(rentalSpecRequest3.getId())
+			.propertyNumber("33333333")
+			.build();
+		final EquipmentRentalSpec rentalSpec4 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec3.getId())
+			.status(RentalSpecStatus.BROKEN)
+			.id(5L)
+			.propertyNumber("44444444")
+			.build();
 
-        final EquipmentRentalSpec rentalSpec1 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec1.getId()).status(RentalSpecStatus.RETURNED)
-                .id(2L).propertyNumber("11111111").build();
-        final EquipmentRentalSpec rentalSpec2 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec2.getId()).status(RentalSpecStatus.LOST)
-                .id(3L).propertyNumber("22222222").build();
-        final EquipmentRentalSpec rentalSpec3 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec2.getId()).status(RentalSpecStatus.OVERDUE_RENTED)
-                .id(rentalSpecRequest3.getId()).propertyNumber("33333333").build();
-        final EquipmentRentalSpec rentalSpec4 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec3.getId()).status(RentalSpecStatus.BROKEN)
-                .id(5L).propertyNumber("44444444").build();
+		given(rentalSpecRepository.findByReservationId(reservationId)).willReturn(
+			List.of(rentalSpec1, rentalSpec2, rentalSpec3, rentalSpec4));
+		doNothing().when(penaltyService)
+			.createOrUpdate(reservation.getMemberId(), reservationId, reservationSpec2.getId(), rentalSpec3.getId(),
+				RentalSpecStatus.OVERDUE_RETURNED);
+		doNothing().when(itemService).setAvailable(rentalSpec3.getPropertyNumber(), true);
 
-        given(rentalSpecRepository.findByReservationId(reservationId)).willReturn(
-            List.of(rentalSpec1, rentalSpec2, rentalSpec3, rentalSpec4));
-        doNothing().when(penaltyService)
-            .createOrUpdate(reservation.getMemberId(), reservationId, reservationSpec2.getId(), rentalSpec3.getId(),
-                RentalSpecStatus.OVERDUE_RETURNED);
-        doNothing().when(itemService).setAvailable(rentalSpec3.getPropertyNumber(), true);
+		// when
+		assertThatCode(() -> rentalService.returnRental(returnReturnRequest))
+			.doesNotThrowAnyException();
 
-        // when
-        assertThatCode(() -> rentalService.returnRental(returnReturnRequest))
-                .doesNotThrowAnyException();
+		// then
+		assertAll(
+			() -> assertThat(reservation.isTerminated()).isTrue(),
+			() -> assertThat(rentalSpec1.getStatus()).isEqualTo(RentalSpecStatus.RETURNED),
+			() -> assertThat(rentalSpec2.getStatus()).isEqualTo(RentalSpecStatus.LOST),
+			() -> assertThat(rentalSpec3.getStatus()).isEqualTo(RentalSpecStatus.OVERDUE_RETURNED),
+			() -> assertThat(rentalSpec4.getStatus()).isEqualTo(RentalSpecStatus.BROKEN),
+			() -> assertThat(reservationSpec1.getStatus()).isEqualTo(ReservationSpecStatus.RETURNED),
+			() -> assertThat(reservationSpec2.getStatus()).isEqualTo(ReservationSpecStatus.ABNORMAL_RETURNED)
+		);
+	}
 
-        // then
-        assertAll(
-                () -> assertThat(reservation.isTerminated()).isTrue(),
-                () -> assertThat(rentalSpec1.getStatus()).isEqualTo(RentalSpecStatus.RETURNED),
-                () -> assertThat(rentalSpec2.getStatus()).isEqualTo(RentalSpecStatus.LOST),
-                () -> assertThat(rentalSpec3.getStatus()).isEqualTo(RentalSpecStatus.OVERDUE_RETURNED),
-                () -> assertThat(rentalSpec4.getStatus()).isEqualTo(RentalSpecStatus.BROKEN),
-                () -> assertThat(reservationSpec1.getStatus()).isEqualTo(ReservationSpecStatus.RETURNED),
-                () -> assertThat(reservationSpec2.getStatus()).isEqualTo(ReservationSpecStatus.ABNORMAL_RETURNED)
-        );
-    }
+	@Test
+	@DisplayName("정상 반납 처리한다.")
+	void return_normal() {
+		// given
+		final RentalPeriod period = new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
+		final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null)
+			.status(ReservationSpecStatus.RETURNED)
+			.period(period)
+			.amount(RentalAmount.ofPositive(1))
+			.id(1L)
+			.build();
+		final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null)
+			.status(ReservationSpecStatus.OVERDUE_RENTED)
+			.period(period)
+			.amount(RentalAmount.ofPositive(2))
+			.id(2L)
+			.build();
+		final Long reservationId = 1L;
+		final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2))
+			.id(reservationId)
+			.build();
+		given(reservationService.getReservationWithReservationSpecsById(reservationId)).willReturn(reservation);
 
-    @Test
-    @DisplayName("정상 반납 처리한다.")
-    void return_normal() {
-        // given
-        final RentalPeriod period = new RentalPeriod(LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
-        final ReservationSpec reservationSpec1 = ReservationSpecFixture.builder(null).status(ReservationSpecStatus.RETURNED)
-                .period(period).amount(RentalAmount.ofPositive(1)).id(1L).build();
-        final ReservationSpec reservationSpec2 = ReservationSpecFixture.builder(null).status(ReservationSpecStatus.OVERDUE_RENTED)
-                .period(period).amount(RentalAmount.ofPositive(2)).id(2L).build();
-        final Long reservationId = 1L;
-        final Reservation reservation = ReservationFixture.builder(List.of(reservationSpec1, reservationSpec2)).id(reservationId).build();
-        given(reservationService.getReservationWithReservationSpecsById(reservationId)).willReturn(reservation);
+		final EquipmentRentalSpec rentalSpec1 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec1.getId())
+			.status(RentalSpecStatus.RETURNED)
+			.id(1L)
+			.propertyNumber("11111111")
+			.build();
+		final EquipmentRentalSpec rentalSpec2 = EquipmentRentalSpecFixture.builder()
+			.reservationId(reservationId)
+			.reservationSpecId(reservationSpec2.getId())
+			.status(RentalSpecStatus.LOST)
+			.id(2L)
+			.propertyNumber("22222222")
+			.build();
 
-        final EquipmentRentalSpec rentalSpec1 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec1.getId()).status(RentalSpecStatus.RETURNED)
-                .id(1L).propertyNumber("11111111").build();
-        final EquipmentRentalSpec rentalSpec2 = EquipmentRentalSpecFixture.builder().reservationId(reservationId).reservationSpecId(reservationSpec2.getId()).status(RentalSpecStatus.LOST)
-                .id(2L).propertyNumber("22222222").build();
+		given(rentalSpecRepository.findByReservationId(reservationId)).willReturn(List.of(rentalSpec1, rentalSpec2));
 
-        given(rentalSpecRepository.findByReservationId(reservationId)).willReturn(List.of(rentalSpec1, rentalSpec2));
+		final ReturnRentalSpecRequest rentalSpecRequest1 = ReturnRentalSpecRequest.builder()
+			.id(rentalSpec1.getId())
+			.status(RentalSpecStatus.RETURNED)
+			.build();
+		final ReturnRentalSpecRequest rentalSpecRequest2 = ReturnRentalSpecRequest.builder()
+			.id(rentalSpec2.getId())
+			.status(RentalSpecStatus.RETURNED)
+			.build();
 
-        final ReturnRentalSpecRequest rentalSpecRequest1 = ReturnRentalSpecRequest.builder().id(rentalSpec1.getId()).status(RentalSpecStatus.RETURNED).build();
-        final ReturnRentalSpecRequest rentalSpecRequest2 = ReturnRentalSpecRequest.builder().id(rentalSpec2.getId()).status(RentalSpecStatus.RETURNED).build();
+		final ReturnRentalRequest returnReturnRequest = ReturnRentalRequest.builder()
+			.reservationId(reservationId)
+			.rentalSpecs(List.of(rentalSpecRequest1, rentalSpecRequest2)).build();
 
-        final ReturnRentalRequest returnReturnRequest = ReturnRentalRequest.builder()
-                .reservationId(reservationId)
-                .rentalSpecs(List.of(rentalSpecRequest1, rentalSpecRequest2)).build();
-
-        // when
-        assertThatCode(() -> rentalService.returnRental(returnReturnRequest))
-                .doesNotThrowAnyException();
-    }
+		// when
+		assertThatCode(() -> rentalService.returnRental(returnReturnRequest))
+			.doesNotThrowAnyException();
+	}
 }


### PR DESCRIPTION
대여 상세의 수령일 필드가 JPA를 통해 저장될 때의 시각으로 초기화 되도록 구현했었다. 문제는 테스트 코드에서 특정 날짜로 대여 상세를 초기화하고 저장하려면 의도한 수령일이 아닌 저장될 때의 시강으로 초기화되는 문제가 있었다. 그래서 해당 기능을 제거하고, 생성자에서 null로 전달 시 현재 시각으로 수령일을 초기화하도록 구현했다.