### PR TITLE
기자재 중복 이름 검증 로직 버그 수정

### DIFF
--- a/src/main/java/com/girigiri/kwrental/asset/domain/RentableAsset.java
+++ b/src/main/java/com/girigiri/kwrental/asset/domain/RentableAsset.java
@@ -29,7 +29,7 @@ public abstract class RentableAsset extends AbstractSuperEntity {
 	@Column(nullable = false)
 	private Long id;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String name;
 
 	@Column(nullable = false)

--- a/src/main/java/com/girigiri/kwrental/asset/equipment/exception/DuplicateAssetNameException.java
+++ b/src/main/java/com/girigiri/kwrental/asset/equipment/exception/DuplicateAssetNameException.java
@@ -1,0 +1,9 @@
+package com.girigiri.kwrental.asset.equipment.exception;
+
+import com.girigiri.kwrental.common.exception.DomainException;
+
+public class DuplicateAssetNameException extends DomainException {
+	public DuplicateAssetNameException(final String name) {
+		super(String.format("%s이라는 자산이 이미 존재하는 것 같습니다.", name));
+	}
+}

--- a/src/main/java/com/girigiri/kwrental/asset/equipment/repository/EquipmentRepository.java
+++ b/src/main/java/com/girigiri/kwrental/asset/equipment/repository/EquipmentRepository.java
@@ -11,4 +11,6 @@ public interface EquipmentRepository extends Repository<Equipment, Long>, Equipm
 	Equipment save(Equipment equipment);
 
 	Optional<Equipment> findById(Long id);
+
+	Optional<Equipment> findByName(String name);
 }

--- a/src/main/java/com/girigiri/kwrental/asset/equipment/service/EquipmentService.java
+++ b/src/main/java/com/girigiri/kwrental/asset/equipment/service/EquipmentService.java
@@ -23,9 +23,11 @@ public class EquipmentService {
 	private final EquipmentRetriever equipmentRetriever;
 	private final EquipmentRepository equipmentRepository;
 	private final ApplicationEventPublisher eventPublisher;
+	private final EquipmentValidator equipmentValidator;
 
 	public Long saveEquipment(final AddEquipmentWithItemsRequest addEquipmentWithItemsRequest) {
 		final AddEquipmentRequest addEquipmentRequest = addEquipmentWithItemsRequest.equipment();
+		equipmentValidator.validateNotExistsByName(addEquipmentRequest.modelName());
 		final Equipment equipment = equipmentRepository.save(mapToEquipment(addEquipmentRequest));
 		itemSaver.saveItems(equipment.getId(), addEquipmentWithItemsRequest.items());
 		return equipment.getId();

--- a/src/main/java/com/girigiri/kwrental/asset/equipment/service/EquipmentValidator.java
+++ b/src/main/java/com/girigiri/kwrental/asset/equipment/service/EquipmentValidator.java
@@ -5,8 +5,10 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.girigiri.kwrental.asset.equipment.domain.Equipment;
+import com.girigiri.kwrental.asset.equipment.exception.DuplicateAssetNameException;
 import com.girigiri.kwrental.asset.equipment.exception.EquipmentException;
 import com.girigiri.kwrental.asset.equipment.exception.EquipmentNotFoundException;
+import com.girigiri.kwrental.asset.equipment.repository.EquipmentRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,12 +18,21 @@ import lombok.RequiredArgsConstructor;
 public class EquipmentValidator {
 
 	private final EquipmentRetriever equipmentRetriever;
+	private final EquipmentRepository equipmentRepository;
 
 	public void validateExistsById(final Long id) {
 		boolean deleted = equipmentRetriever.getEquipment(id).isDeleted();
 		if (deleted) {
 			throw new EquipmentNotFoundException();
 		}
+	}
+
+	public void validateNotExistsByName(final String name) {
+		equipmentRepository.findByName(name)
+			.ifPresent(found -> {
+				if (!found.isDeleted())
+					throw new DuplicateAssetNameException(name);
+			});
 	}
 
 	public Equipment validateRentalDays(final Long id, final Integer rentalDays) {

--- a/src/main/resources/db/migration/V1_3__dropAssetNameUnique.sql
+++ b/src/main/resources/db/migration/V1_3__dropAssetNameUnique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `asset`
+    DROP INDEX `UK_ASSET_NAME`;

--- a/src/test/java/com/girigiri/kwrental/asset/equipment/repository/EquipmentRepositoryTest.java
+++ b/src/test/java/com/girigiri/kwrental/asset/equipment/repository/EquipmentRepositoryTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -48,18 +47,5 @@ class EquipmentRepositoryTest {
                 () -> assertThat(equipmentsPage.getTotalElements()).isEqualTo(3),
                 () -> assertThat(equipmentsPage.getContent()).containsExactly(equipment3, equipment2)
         );
-    }
-
-    @Test
-    @DisplayName("중복된 모델이름으로 기자재를 등록하려면 예외가 발생한다.")
-    void save_duplicatedname() {
-        // given
-        final Equipment equipment = EquipmentFixture.create();
-        equipmentRepository.save(equipment);
-        final Equipment duplicatedModelNameEquipment = EquipmentFixture.create();
-
-        // when, then
-        assertThatThrownBy(() -> equipmentRepository.save(duplicatedModelNameEquipment))
-                .isExactlyInstanceOf(DataIntegrityViolationException.class);
     }
 }


### PR DESCRIPTION
기자재를 등록하려고 할 때 조교 입장에서 분명 없는 기자재 이름인데 이름이 중복되어 등록이 안되는 버그 수정
과거 동일한 이름의 기자재가 등록되었다가 삭제 처리되어 데이터베이스에 남아있기 때문.

그래서 디비의 유니크 제약 조건으로 검증했던 것을 애플리케이션에서 추가하려고 할 때 검증하는 것으로 수정